### PR TITLE
Update ryu-cho.yaml

### DIFF
--- a/.github/workflows/ryu-cho.yaml
+++ b/.github/workflows/ryu-cho.yaml
@@ -16,7 +16,7 @@ jobs:
           email: ${{ secrets.RYU_CHO_USER_EMAIL }}
           upstream-repo: https://github.com/vuejs-translations/docs-ja.git
           upstream-repo-branch: main
-          head-repo: https://github.com/vuejs/docs.git
+          head-repo: https://github.com/vuejs/docs
           head-repo-branch: main
           track-from: b27e90689cb81114317fda8d6f9099ad4d68590c
           # path-starts-with: src/


### PR DESCRIPTION
ryu-cho の実行結果が `Error: Status code 404` となっているので修正

https://github.com/vitejs/docs-ja や https://github.com/vuejs-jp/ja.vuejs.org の設定を見たら `.git` がついていなかったので、こちらも削除してみます
（これでだめなら `path-starts-with` のコメントアウトを外します）