### PR TITLE
docs: fix typo (#57)

### DIFF
--- a/src/api/sfc-css-features.md
+++ b/src/api/sfc-css-features.md
@@ -120,7 +120,7 @@ A `<style module>` tag is compiled as [CSS Modules](https://github.com/css-modul
 
 The resulting classes are hashed to avoid collision, achieving the same effect of scoping the CSS to the current component only.
 
-Refer to the [CSS Modules spec](https://github.com/css-modules/css-modules) for mode details such as [global exceptions](https://github.com/css-modules/css-modules#exceptions) and [composition](https://github.com/css-modules/css-modules#composition).
+Refer to the [CSS Modules spec](https://github.com/css-modules/css-modules) for more details such as [global exceptions](https://github.com/css-modules/css-modules#exceptions) and [composition](https://github.com/css-modules/css-modules#composition).
 
 ### Custom Inject Name
 


### PR DESCRIPTION
resolves #57
Cherry picked from https://github.com/vuejs/docs/commit/c78a8601918076526a9ed99b8ba813df61a0cfa3