### PR TITLE
fix (guides): typo in reactivity fundamentals (#136)

### DIFF
--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -464,7 +464,7 @@ const { foo } = object
 {{ foo }} <!-- properly unwrapped -->
 ```
 
-Now `foo` will be wrapped as expected.
+Now `foo` will be unwrapped as expected.
 
 ### Ref Unwrapping in Reactive Objects \*\*
 


### PR DESCRIPTION
resolves #136
Cherry picked from https://github.com/vuejs/docs/commit/cebc370aa2e89b602f549ac9a18efc3fc8508ced