### PR TITLE
chore: fix typo in code example (#138)

### DIFF
--- a/src/guide/built-ins/transition.md
+++ b/src/guide/built-ins/transition.md
@@ -476,7 +476,7 @@ Transitions can be reused through Vue's component system. To create a reusable t
     @leave="onLeave">
     <slot></slot> <!-- pass down slot content -->
   </Transition>
-</tempalte>
+</template>
 
 <style>
 /*

--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -464,7 +464,7 @@ const { foo } = object
 {{ foo }} <!-- properly unwrapped -->
 ```
 
-Now `foo` will be wrapped as expected.
+Now `foo` will be unwrapped as expected.
 
 ### Ref Unwrapping in Reactive Objects \*\*
 


### PR DESCRIPTION
resolves #138
Cherry picked from https://github.com/vuejs/docs/commit/00d2dc42238d1cb6c5393ca18c0d9243cc626283