### PR TITLE
package.json で Node バージョンと packageManager を指定

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "engines": {
+    "node": ">=14.19.0"
+  },
+  "packageManager": "pnpm@6.30.1",
   "scripts": {
     "dev": "vitepress",
     "build": "vitepress build",


### PR DESCRIPTION
package.json で Node バージョンと packageManager を指定

- フィールドの値を書き換えると `pnpm -v` の結果が変わることを確認
- pnpm は現時点の最新バージョンを指定
