### PR TITLE
Hide <td> scroll in 7guis cell example

Scrolling of the <td>'s does seem to be unwanted here, and I suggest to hide it (#192)

### DIFF
--- a/src/examples/src/cells/App/style.css
+++ b/src/examples/src/cells/App/style.css
@@ -23,5 +23,5 @@ tr:first-of-type th:first-of-type {
 td {
   border: 1px solid #ccc;
   height: 1.5em;
-  overflow: scroll;
+  overflow: hidden;
 }


### PR DESCRIPTION
resolves #192
Cherry picked from https://github.com/vuejs/docs/commit/89b8d9f9737614bf2be83d36562d94a83f17dac7