### PR TITLE
Add info about v-bind in CSS under CSSProperties

When using SFC its often not necessary to do type augmentation if v-bind in CSS is used. (#194)

### DIFF
--- a/src/api/utility-types.md
+++ b/src/api/utility-types.md
@@ -128,3 +128,9 @@ Used to augment allowed values in style property bindings.
  :::tip
   Augmentations must be placed in a module `.ts` or `.d.ts` file. See [Type Augmentation Placement](/guide/typescript/options-api.html#augmenting-global-properties) for more details.
   :::
+  
+  :::info See also
+SFC `<style>` tags support linking CSS values to dynamic component state using the `v-bind CSS` function. This allows for custom properties without type augmentation. 
+
+- [v-bind() in CSS](/api/sfc-css-features.html#v-bind-in-css)
+  :::


### PR DESCRIPTION
resolves #194
Cherry picked from https://github.com/vuejs/docs/commit/32754df4035c5417f35be3fd5773bb033dee86eb