### PR TITLE
chore(slots): fix typo

Fix a confusion between header and footer (#254)

### DIFF
--- a/src/guide/components/slots.md
+++ b/src/guide/components/slots.md
@@ -405,7 +405,7 @@ Named scoped slots work similarly - slot props are accessible as the value of th
   </template>
 
   <template #footer="footerProps">
-    {{ headerProps }}
+    {{ footerProps }}
   </template>
 </MyComponent>
 ```


### PR DESCRIPTION
resolves #254
Cherry picked from https://github.com/vuejs/docs/commit/16844d3c70b1db7c126f07959babbf1b82eea00b