### PR TITLE
Remove redundancy in reactivity-fundamentals.md

The clause following the 3rd "or"  is redundant and may cause confusion. Removing it will make the explanation better match the code example. (#346)

### DIFF
--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -352,7 +352,7 @@ The `reactive()` API has two limitations:
    state = reactive({ count: 1 })
    ```
 
-   It also means that when we assign or destructure a reactive object's property into local variables, or when we pass that property into a function, or destructure properties from a reactive object, we will lose the reactivity connection:
+   It also means that when we assign or destructure a reactive object's property into local variables, or when we pass that property into a function, we will lose the reactivity connection:
 
    ```js
    const state = reactive({ count: 0 })


### PR DESCRIPTION
resolves #346
Cherry picked from https://github.com/vuejs/docs/commit/dd48f0035d932b77f08f84a7cb8784a4ec74e835