### PR TITLE
Fix punctuation mark typos

### DIFF
--- a/src/guide/essentials/event-handling.md
+++ b/src/guide/essentials/event-handling.md
@@ -194,7 +194,7 @@ methods: {
 
 ```js
 function warn(message, event) {
-  // `これでネイティブイベントにアクセスできるようになりました`
+  // これでネイティブイベントにアクセスできるようになりました
   if (event) {
     event.preventDefault()
   }


### PR DESCRIPTION
resolve #353

vuejs/docs@dfa7fab の反映です。
334行目にはすでに句点がついていたので修正なし