### PR TITLE
docs: Update `useDebouncedRef` usage

Fixes issue with `useDebouncedRef` function so it can be readily imported to a project. (#369)

### DIFF
--- a/src/api/reactivity-advanced.md
+++ b/src/api/reactivity-advanced.md
@@ -94,7 +94,9 @@ Creates a customized ref with explicit control over its dependency tracking and 
   Creating a debounced ref that only updates the value after a certain timeout after the latest set call:
 
   ```js
-  function useDebouncedRef(value, delay = 200) {
+  import { customRef } from 'vue'
+  
+  export function useDebouncedRef(value, delay = 200) {
     let timeout
     return customRef((track, trigger) => {
       return {

--- a/src/guide/scaling-up/ssr.md
+++ b/src/guide/scaling-up/ssr.md
@@ -163,7 +163,7 @@ import { createSSRApp } from 'vue'
 export function createApp() {
   return createSSRApp({
     data: () => ({ count: 1 }),
-    template: `<div @click="count++">{{ count }}</div>`
+    template: `<button @click="count++">{{ count }}</button>`
   })
 }
 ```


### PR DESCRIPTION
resolves #369
Cherry picked from https://github.com/vuejs/docs/commit/c8e0781903a4553f1f5efff4bae4b1d00c49e369