### PR TITLE
Added transition mode `default`

According to the TypeScript interface [here](https://github.com/vuejs/core/blob/main/packages/runtime-core/src/components/BaseTransition.ts#L24) the default mode is `default`. This was missing from the docs. (#424)

### DIFF
--- a/src/api/built-in-components.md
+++ b/src/api/built-in-components.md
@@ -55,7 +55,7 @@ Provides animated transition effects to a **single** element or component.
      * Controls the timing sequence of leaving/entering transitions.
      * Default behavior is simultaneous.
      */
-    mode?: 'in-out' | 'out-in'
+    mode?: 'in-out' | 'out-in' | 'default'
     /**
      * Whether to apply transition on initial render.
      * Default: false


### PR DESCRIPTION
resolves #424
Cherry picked from https://github.com/vuejs/docs/commit/11ae1e29875ad4b82b357849d4b7e5eaa97e970e