### PR TITLE
docs: refine the `application` documentation link (#456)

### DIFF
--- a/src/api/application.md
+++ b/src/api/application.md
@@ -400,7 +400,7 @@ Configure runtime compiler options. Values set on this object will be passed to 
 ::: warning Important
 This config option is only respected when using the full build (i.e. the standalone `vue.js` that can compile templates in the browser). If you are using the runtime-only build with a build setup, compiler options must be passed to `@vue/compiler-dom` via build tool configurations instead.
 
-- For `vue-loader`: [pass via the `compilerOptions` loader option](/). Also see [how to configure it in `vue-cli`](/).
+- For `vue-loader`: [pass via the `compilerOptions` loader option](https://vue-loader.vuejs.org/options.html#compileroptions). Also see [how to configure it in `vue-cli`](https://cli.vuejs.org/guide/webpack.html#modifying-options-of-a-loader).
 
 - For `vite`: [pass via `@vitejs/plugin-vue` options](/).
   :::


### PR DESCRIPTION
resolves #456
Cherry picked from https://github.com/vuejs/docs/commit/aac00ea380168e2a8a77b421a6601788ff063085