### PR TITLE
Fix for #1691

* Fix for #1691

According to previous steps an <a href=""> where used where as in step #15 used markdown based links [Examples](/examples) which somehow caused 404.

* Removed Spacing per. request

* createMarkdownRenderer and revert for step 15 (#527)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@nexhome/yorkie': ^2.0.8

--- a/src/tutorial/tutorial.data.ts
+++ b/src/tutorial/tutorial.data.ts
@@ -11,7 +11,7 @@ export default {
     const md = createMarkdownRenderer(process.cwd(), {
       // @ts-ignore
       highlight: await createHighlighter()
-    })
+    }, '/')
     const files = readExamples(path.resolve(__dirname, './src'))
     for (const step in files) {
       const stepFiles = files[step]


### PR DESCRIPTION
resolves #527
Cherry picked from https://github.com/vuejs/docs/commit/3df42ca38e0559f9194fdaa0f59d9ee2a7acdb45