### PR TITLE
Align description about props default between composition/options API

* fix missing addition about rawProps

* remove duplicate description about rawProps

Co-authored-by: junichi-chiba <junichi.chiba@atglobal.co.jp> (#539)

### DIFF
--- a/src/guide/components/props.md
+++ b/src/guide/components/props.md
@@ -398,8 +398,9 @@ defineProps({
   propE: {
     type: Object,
     // Object or array defaults must be returned from
-    // a factory function
-    default() {
+    // a factory function. The function receives the raw
+    // props received by the component as the argument.
+    default(rawProps) {
       return { message: 'hello' }
     }
   },
@@ -453,7 +454,6 @@ export default {
       // a factory function. The function receives the raw
       // props received by the component as the argument.
       default(rawProps) {
-        // default function receives the raw props object as argument
         return { message: 'hello' }
       }
     },


### PR DESCRIPTION
resolves #539
Cherry picked from https://github.com/vuejs/docs/commit/929f0d59813b584497fc76c4cbfff1b85b41c3b9