### PR TITLE
docs: remove @next tag from @test-library/vue package

As of [this commit](https://github.com/testing-library/testing-library-docs/commit/ac0737e57af1b3b86cea039beef631e7e52b67f7) the testing library dependency for vue3 is the default one, so no need for the `next` tag. (#607)

### DIFF
--- a/src/guide/scaling-up/testing.md
+++ b/src/guide/scaling-up/testing.md
@@ -288,7 +288,7 @@ Vitest とブラウザーベースのランナーの主な違いは、スピー�
 Vite ベースの Vue プロジェクトでは、以下を実行します:
 
 ```sh
-> npm install -D vitest happy-dom @testing-library/vue@next
+> npm install -D vitest happy-dom @testing-library/vue
 ```
 
 次に、Vite の設定を更新して `test` オプションブロックを追加します:


### PR DESCRIPTION
resolves #607
Cherry picked from https://github.com/vuejs/docs/commit/25f50103b835b360f0eab433f793aa24265981c7