### PR TITLE
Update sfc-script-setup.md

This makes a very small change to one of the examples given in the documention.

There was a click handler on a `div` element as opposed to an interactive element such as `button`. This switches it to button simply to be consistent with best practices around accessibility (#634)

### DIFF
--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -35,7 +35,7 @@ function log() {
 </script>
 
 <template>
-  <div @click="log">{{ msg }}</div>
+  <button @click="log">{{ msg }}</button>
 </template>
 ```
 


### PR DESCRIPTION
resolves #634
Cherry picked from https://github.com/vuejs/docs/commit/98b4d20b66b6903c71464021d4e766d2adb7694c