### PR TITLE
Update _redirects for existing v2 runtime warning links

* Update _redirects

* Update _redirects

* Update _redirects (#686)

### DIFF
--- a/src/public/_redirects
+++ b/src/public/_redirects
@@ -3,6 +3,19 @@
 /ecosystem/partners.html  /partners/
 /resources/*              /ecosystem/:splat
 
+# From Vue v2 runtime warnings
+
+/guide/computed.html                https://v2.vuejs.org/v2/guide/computed.html
+/guide/custom-directive.html        https://v2.vuejs.org/v2/guide/custom-directive.html
+/guide/deployment.html              https://v2.vuejs.org/v2/guide/deployment.html
+/guide/list.html                    https://v2.vuejs.org/v2/guide/list.html
+# https://vuejs.org/v2/api/#data
+# /v2/api/                            https://v2.vuejs.org/v2/api/
+# https://vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties
+# /v2/guide/reactivity.html           https://v2.vuejs.org/v2/guide/reactivity.html
+# https://vuejs.org/v2/guide/components.html#data-Must-Be-a-Function
+# /v2/guide/components.html           https://v2.vuejs.org/v2/guide/components.html
+
 /v2/guide/team.html                 /about/team.html
 /v2/guide/join.html                 /about/community-guide.html
 /v2/examples/                       https://vuejs.org/examples/#markdown


### PR DESCRIPTION
resolves #686
Cherry picked from https://github.com/vuejs/docs/commit/ec001e7562c6e4d238ad1bf2c400077844aaae6b