### PR TITLE
Fix vue mastery banner z-order

closes #1846 (#697)

### DIFF
--- a/.vitepress/theme/components/VueMasteryBanner.vue
+++ b/.vitepress/theme/components/VueMasteryBanner.vue
@@ -43,7 +43,7 @@ function close () {
   overflow: hidden;
   position: fixed;
   top: 0;
-  z-index: 2;
+  z-index: var(--vp-z-index-banner);
   width: 100%;
   transition: all 0.3s ease-out 0.1s;
 }


### PR DESCRIPTION
resolves #697
Cherry picked from https://github.com/vuejs/docs/commit/76526bf8f0ce89b9b4072ba87813bf2365cb1f8e