### PR TITLE
Fix typo - hyphenate Single-File Component

### DIFF
--- a/src/tutorial/src/step-2/description.md
+++ b/src/tutorial/src/step-2/description.md
@@ -2,7 +2,7 @@
 
 <div class="sfc">
 
-エディターに表示されているのは、Vue Single File Component (SFC) です。SFC は再利用可能な自己完結型のコードブロックであり、一緒に属する HTML、CSS、JavaScript をカプセル化して `.vue` ファイル内に記述します。
+エディターに表示されているのは、Vue の単一ファイルコンポーネント（SFC）です。SFC は再利用可能な自己完結型のコードブロックであり、一緒に属する HTML、CSS、JavaScript をカプセル化して `.vue` ファイル内に記述します。
 
 </div>
 


### PR DESCRIPTION
resolve #654

vuejs/docs@4e50369 では SFC のハイフンを修正していますが、日本語に変更しました
（他にも英語のままになっている箇所があるので issue 建てておきます）