### PR TITLE
Swapping `indexOf` to `includes` in comparisons

This proposal is to remove the usage of the `indexOf` method when testing for the presence of a given character in a string. While `indexOf` is compatible with IE, `includes` is friendlier to newer JavaScript developers and it improves code readability. (#733)

### DIFF
--- a/src/guide/essentials/watchers.md
+++ b/src/guide/essentials/watchers.md
@@ -19,7 +19,7 @@ export default {
   watch: {
     // 問題内容が変更されるたびに、関数が実行されます。
     question(newQuestion, oldQuestion) {
-      if (newQuestion.indexOf('?') > -1) {
+      if (newQuestion.includes('?')) {
         this.getAnswer()
       }
     }


### PR DESCRIPTION
resolves #733
Cherry picked from https://github.com/vuejs/docs/commit/1df1e0e22fac0b0db0e1590597d99d78bba04fe5