### PR TITLE
Change v-model for multiline example

In multiline example was used message ref for v-model, so example above "message" was changing if we writed something in multiline section. (#745)

### DIFF
--- a/src/guide/essentials/forms.md
+++ b/src/guide/essentials/forms.md
@@ -87,8 +87,8 @@ const multiSelected = ref([])
 
 <div class="demo">
   <span>Multiline message is:</span>
-  <p style="white-space: pre-line;">{{ message }}</p>
-  <textarea v-model="message" placeholder="add multiple lines"></textarea>
+  <p style="white-space: pre-line;">{{ multilineText }}</p>
+  <textarea v-model="multilineText" placeholder="add multiple lines"></textarea>
 </div>
 
 <div class="composition-api">


### PR DESCRIPTION
resolves #745
Cherry picked from https://github.com/vuejs/docs/commit/85d5de00a4b787804603b8555f00c34a4c80c511