### PR TITLE
Fixed a grammar mistake

### DIFF
--- a/src/guide/essentials/watchers.md
+++ b/src/guide/essentials/watchers.md
@@ -6,7 +6,7 @@
 
 <div class="options-api">
 
-Option API では、[`watch` オプション](/api/options-state.html#watch) を使って、リアクティブなプロパティが変更されるたびに関数を実行することができます:
+Options API では、[`watch` オプション](/api/options-state.html#watch) を使って、リアクティブなプロパティが変更されるたびに関数を実行することができます:
 
 ```js
 export default {


### PR DESCRIPTION
resolve #690

本家の vuejs/docs@4eb8569 では `the` を追加する修正なので直接関係ないのですが、該当箇所が `Option API` になっているのに気づいたので修正しました