### PR TITLE
トップページ翻訳

### DIFF
--- a/.vitepress/theme/components/Home.vue
+++ b/.vitepress/theme/components/Home.vue
@@ -18,13 +18,13 @@ onMounted(async () => {
       <br />JavaScript Framework
     </h1>
     <p class="description">
-      An approachable, performant and versatile framework for building web
-      user interfaces.
+      Web ユーザーインターフェース構築のための、親しみやすく、パフォーマンスと汎用性の高いフレームワーク。
+
     </p>
     <p class="actions">
       <vue-mastery-modal />
       <a class="get-started" href="/guide/introduction.html">
-        Get Started
+        はじめる
         <svg
           class="icon"
           xmlns="http://www.w3.org/2000/svg"
@@ -37,12 +37,12 @@ onMounted(async () => {
           />
         </svg>
       </a>
-      <a class="setup" href="/guide/quick-start.html">Install</a>
+      <a class="setup" href="/guide/quick-start.html">インストール</a>
     </p>
   </section>
 
   <section id="special-sponsor">
-    <span>Special Sponsor</span>
+    <span>スペシャルスポンサー</span>
     <template v-if="data && data.special">
       <template v-for="{ url, img, name, description } of data.special">
         <a :href="url" target="_blank" rel="sponsored noopener">
@@ -59,32 +59,32 @@ onMounted(async () => {
 
   <section id="highlights" class="vt-box-container">
     <div class="vt-box">
-      <h2>Approachable</h2>
+      <h2>親しみやすい</h2>
       <p>
-        Builds on top of standard HTML, CSS and JavaScript with intuitive
-        API and world-class documentation.
+        直感的な API とワールドクラスのドキュメントを使用して、標準的な
+        HTML、CSS、JavaScript をもとに構築します。
       </p>
     </div>
     <div class="vt-box">
-      <h2>Performant</h2>
+      <h2>高パフォーマンス</h2>
       <p>
-        Truly reactive, compiler-optimized rendering system that rarely
-        requires manual optimization.
+        手動での最適化をほとんど必要としない、真にリアクティブなコンパイラで最適化されたレンダリングシステム。
+
       </p>
     </div>
     <div class="vt-box">
-      <h2>Versatile</h2>
+      <h2>多用途</h2>
       <p>
-        A rich, incrementally adoptable ecosystem that scales between a
-        library and a full-featured framework.
+        ライブラリーとフル機能のフレームワークの間でスケールする、リッチで段階的に採用可能なエコシステム。
+
       </p>
     </div>
   </section>
 
   <section id="sponsors">
-    <h2>Platinum Sponsors</h2>
+    <h2>プラチナスポンサー</h2>
     <SponsorsGroup tier="platinum" placement="landing" />
-    <h2>Gold Sponsors</h2>
+    <h2>ゴールドスポンサー</h2>
     <SponsorsGroup tier="gold" placement="landing" />
   </section>
 

--- a/.vitepress/theme/components/NewsLetter.vue
+++ b/.vitepress/theme/components/NewsLetter.vue
@@ -5,7 +5,7 @@ import { VTLink } from '@vue/theme'
 <template>
   <section id="newsletter" class="NewsLetter">
     <div class="container">
-      <h2 class="title">Subscribe to our weekly newsletter.</h2>
+      <h2 class="title">毎週配信されるニュースレターを購読する。</h2>
 
       <div class="form">
         <form
@@ -32,21 +32,21 @@ import { VTLink } from '@vue/theme'
               id="member_submit"
               name="member[subscribe]"
               type="submit"
-              value="SUBSCRIBE"
+              value="購読する"
             />
           </div>
         </form>
       </div>
 
       <p class="help">
-        You can read the previous issues and listen to our podcast at
+
         <VTLink
           class="link"
           href="https://news.vuejs.org/"
           no-icon
-        >news.vuejs.org</VTLink>. You may also go social at
-        <VTLink class="link" href="https://twitter.com/vuejs" no-icon>Twitter</VTLink>, or join our home at
-        <VTLink class="link" href="https://chat.vuejs.org/" no-icon>Discord</VTLink>.
+        >news.vuejs.org</VTLink>で過去の号を読んだり、ポッドキャストを聴いたりできます。<br />
+        さらに、<VTLink class="link" href="https://twitter.com/vuejs" no-icon>Twitter</VTLink> で交流したり
+        <VTLink class="link" href="https://chat.vuejs.org/" no-icon>Discord</VTLink> で私たちのホームに参加したりできます。
       </p>
     </div>
   </section>

--- a/.vitepress/theme/components/SponsorsGroup.vue
+++ b/.vitepress/theme/components/SponsorsGroup.vue
@@ -57,7 +57,7 @@ onMounted(async () => {
       v-if="placement !== 'page' && tier !== 'special'"
       href="/sponsor/"
       class="sponsor-item action"
-      >Your logo</a
+      >あなたのロゴ</a
     >
   </div>
 </template>

--- a/.vitepress/theme/components/VueMasteryModal.vue
+++ b/.vitepress/theme/components/VueMasteryModal.vue
@@ -33,7 +33,7 @@ watch(
         d="M50,3.8C24.5,3.8,3.8,24.5,3.8,50S24.5,96.2,50,96.2S96.2,75.5,96.2,50S75.5,3.8,50,3.8z M71.2,53.3l-30.8,18  c-0.6,0.4-1.3,0.5-1.9,0.5c-0.6,0-1.3-0.1-1.9-0.5c-1.2-0.6-1.9-1.9-1.9-3.3V32c0-1.4,0.8-2.7,1.9-3.3c1.2-0.6,2.7-0.6,3.8,0  l30.8,18c1.2,0.6,1.9,1.9,1.9,3.3S72.3,52.7,71.2,53.3z"
       ></path>
     </svg>
-    Why Vue
+    Vue を使う理由
   </a>
   <Teleport v-if="showWhyVue" to="body">
     <div
@@ -65,23 +65,22 @@ watch(
 
           <div class="vuemastery-modal-footer">
             <p class="vuemastery-modal-footer-text">
-              Video by
               <a
                 href="https://www.vuemastery.com"
                 target="_blank"
                 rel="sponsored noopener"
                 title="Vue.js Courses on Vue Mastery"
               >
-                Vue Mastery.</a
-              > Watch Vue Mastery’s free
+                Vue Mastery</a
+              >による動画。Vue Mastery の無料
               <a
                 href="https://www.vuemastery.com/courses/intro-to-vue-3/intro-to-vue3"
                 target="_blank"
                 rel="sponsored noopener"
                 title="Vue.js Courses on Vue Mastery"
               >
-                Intro to Vue course.</a
-              >
+                Vue 入門コース</a
+              >をご覧ください。
             </p>
           </div>
         </div>


### PR DESCRIPTION
トップページを翻訳しました。

表題の `The Progressive JavaScript Framework` については [v2](https://jp.vuejs.org/), [v3](https://v3.ja.vuejs.org/) ともに英語のままだったので、そのままにしてあります。
（[中国版](https://cn.vuejs.org/)では中国語になっている）