### PR TITLE
fix: partner shuffling bug in prod mode

* fix: partner shuffling bug in prod mode

* Update PartnerList.vue (#849)

### DIFF
--- a/src/partners/components/PartnerList.vue
+++ b/src/partners/components/PartnerList.vue
@@ -45,7 +45,10 @@ function shuffle(array: Array<any>) {
 
 <template>
   <div class="PartnerList" v-show="mounted">
-    <PartnerCard v-for="p in filtered" :key="p.name" :data="p" />
+    <!-- to skip SSG since the partners are shuffled -->
+    <ClientOnly>
+      <PartnerCard v-for="p in filtered" :key="p.name" :data="p" />
+    </ClientOnly>
   </div>
 </template>
 


### PR DESCRIPTION
resolves #849
Cherry picked from https://github.com/vuejs/docs/commit/2019035796a19986451276b7fbe3d8bc492a8964