### PR TITLE
fix special sponsor layout problem on zh-cn doc.

<img width="1070" alt="image" src="https://user-images.githubusercontent.com/206848/188817283-0d6ca1a2-ecb6-40c8-bb0b-788f9ba63a7c.png">

ref: https://github.com/vuejs-translations/docs-zh-cn/pull/536 (#854)

### DIFF
--- a/.vitepress/theme/components/Home.vue
+++ b/.vitepress/theme/components/Home.vue
@@ -52,7 +52,7 @@ onMounted(async () => {
           </picture>
           <img v-else :src="`${base}/images/${img}`" :alt="name" />
         </a>
-        <span v-if="description">{{ description }}</span>
+        <span>{{ description }}</span>
       </template>
     </template>
   </section>
@@ -179,6 +179,7 @@ html:not(.dark) .accent,
   border-bottom: 1px solid var(--vt-c-divider-light);
   padding: 12px 24px;
   display: flex;
+  align-items: center;
 }
 
 #special-sponsor span {


### PR DESCRIPTION
resolves #854
Cherry picked from https://github.com/vuejs/docs/commit/fea572ef3512f6fc19aad8aa65c668d4cecd109c