### PR TITLE
fix: Typo in Typescript tip

Fix a typo within Tip example in Typescript configuration file. (#913)

### DIFF
--- a/src/guide/scaling-up/testing.md
+++ b/src/guide/scaling-up/testing.md
@@ -310,7 +310,7 @@ TypeScript を使用している場合は、`tsconfig.json` の `types` フィ�
 // tsconfig.json
 
 {
- "compileroptions": {
+ "compilerOptions": {
     "types": ["vitest/globals"]
   }
 }


### PR DESCRIPTION
resolves #913
Cherry picked from https://github.com/vuejs/docs/commit/50d2a819e9dca082af6099a515036d3dbb64a74d