### PR TITLE
docs: Add a virtual list library

Since [vue-virtual-scroller](https://github.com/Akryum/vue-virtual-scroller) don't have types, it's necessary to introduce a new library. (#925)

### DIFF
--- a/src/guide/best-practices/performance.md
+++ b/src/guide/best-practices/performance.md
@@ -138,6 +138,7 @@ Vue では、子コンポーネントは、受け取ったプロパティのう�
 
 - [vue-virtual-scroller](https://github.com/Akryum/vue-virtual-scroller)
 - [vue-virtual-scroll-grid](https://github.com/rocwang/vue-virtual-scroll-grid)
+- [vueuc/VVirtualList](https://github.com/07akioni/vueuc)
 
 ### 大きなイミュータブルな構造のリアクティビティーオーバーヘッドを減らす
 


### PR DESCRIPTION
resolves #925
Cherry picked from https://github.com/vuejs/docs/commit/ad4caf0158da5decf6388869213dda8c03a4391a