### PR TITLE
Change emit example function name for clarity

* Change emit example function name for clarity

Hello,

I suggest changing the function name in the "component instance" example from `submit` to `someEvent` (and also possibly adding some extra HTML example code for added clarity)

As-is, I did not immediately see the connection between "submit" and the following code, which references "some-event"

I'm just learning Vue and was a little confused by this section in the docs. It's very possible I'm still confused, in which case, please disregard :)

* Remove template snippet (#929)

### DIFF
--- a/src/guide/components/events.md
+++ b/src/guide/components/events.md
@@ -23,7 +23,7 @@
 export default {
   methods: {
     submit() {
-      this.$emit('submit')
+      this.$emit('someEvent')
     }
   }
 }


### PR DESCRIPTION
resolves #929
Cherry picked from https://github.com/vuejs/docs/commit/1f0490f1a0c0abd575eb5fbce8cf8c0dc6520301