### PR TITLE
Add class to the Skip Link in the accessibility.md

- CSS syntax is case-insensitive so it is better to use kebab case (skip-link) instead of camel case (skipLink)
- The anchor tag must have a class of skip-link (#1041)

### DIFF
--- a/src/guide/best-practices/accessibility.md
+++ b/src/guide/best-practices/accessibility.md
@@ -15,7 +15,7 @@ Web アクセシビリティー（a11y としても知られます）とは、�
 ```vue-html
 <ul class="skip-links">
   <li>
-    <a href="#main" ref="skipLink">Skip to main content</a>
+    <a href="#main" ref="skipLink" class="skip-link">Skip to main content</a>
   </li>
 </ul>
 ```
@@ -23,7 +23,7 @@ Web アクセシビリティー（a11y としても知られます）とは、�
 フォーカスされない限りリンクを非表示にするには、以下のようなスタイルを追加します:
 
 ```css
-.skipLink {
+.skip-link {
   white-space: nowrap;
   margin: 1em auto;
   top: 0;
@@ -32,7 +32,7 @@ Web アクセシビリティー（a11y としても知られます）とは、�
   margin-left: -72px;
   opacity: 0;
 }
-.skipLink:focus {
+.skip-link:focus {
   opacity: 1;
   background-color: white;
   padding: 0.5em;


### PR DESCRIPTION
resolves #1041
Cherry picked from https://github.com/vuejs/docs/commit/7f3b9a56a7ec52418c458991728fab1823e446cb