### PR TITLE
MDN のリンクを日本語版のページに

### DIFF
--- a/src/api/built-in-special-elements.md
+++ b/src/api/built-in-special-elements.md
@@ -152,7 +152,7 @@ DOM に要素をレンダリングせずに組み込みディレクティブを�
   - `v-for`
   - `v-slot`
 
-  これらのディレクティブが存在しない場合は、代わりに[ネイティブの `<template>` 要素](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template)としてレンダリングされます。
+  これらのディレクティブが存在しない場合は、代わりに[ネイティブの `<template>` 要素](https://developer.mozilla.org/ja/docs/Web/HTML/Element/template)としてレンダリングされます。
 
   `v-for` を持つ `<template>` は [`key` 属性](/api/built-in-special-attributes.html#key)を持たせることができます。それ以外の属性やディレクティブは、対応する要素がなければ意味をなさないので、すべて破棄されます。
 

--- a/src/api/reactivity-core.md
+++ b/src/api/reactivity-core.md
@@ -131,7 +131,7 @@
 
   深い変換を避け、ルートレベルのリアクティビティーのみを保持するためには、代わりに [shallowReactive()](./reactivity-advanced.html#shallowreactive) 使用します。
 
-  返されたオブジェクトとそのネストされたオブジェクトは [ES Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) でラップされ、元のオブジェクトと**等しくなりません**。元のオブジェクトに依存することを避け、リアクティブなプロキシのみを使用することが推奨されます。
+  返されたオブジェクトとそのネストされたオブジェクトは [ES Proxy](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Proxy) でラップされ、元のオブジェクトと**等しくなりません**。元のオブジェクトに依存することを避け、リアクティブなプロキシのみを使用することが推奨されます。
 
 - **例**
 

--- a/src/guide/best-practices/accessibility.md
+++ b/src/guide/best-practices/accessibility.md
@@ -114,7 +114,7 @@ watch(
 
 ### ランドマーク {#landmarks}
 
-[ランドマーク](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/landmark_role)は、アプリケーション内のセクションへのプログラムによるアクセスを提供します。アシスティブ・テクノロジー（支援技術）に依存するユーザーは、アプリケーションの各セクションに移動し、コンテンツをスキップすることができます。これを実現するために、[ARIA ロール](https://developer.mozilla.org/ja/docs/Web/Accessibility/ARIA/Roles)を使用できます。
+[ランドマーク](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/landmark_role)<!-- TODO: 日本語版のページが出来たら URL 差し替え -->は、アプリケーション内のセクションへのプログラムによるアクセスを提供します。アシスティブ・テクノロジー（支援技術）に依存するユーザーは、アプリケーションの各セクションに移動し、コンテンツをスキップすることができます。これを実現するために、[ARIA ロール](https://developer.mozilla.org/ja/docs/Web/Accessibility/ARIA/Roles)を使用できます。
 
 | HTML            | ARIA ロール            | ランドマークの目的                                                                                                 |
 | --------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------- |
@@ -188,7 +188,7 @@ Chrome デベロッパー ツールでこの要素を検査し、Elements タブ
 
 #### `aria-label` {#aria-label}
 
-[`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) で入力欄にアクセシブルな名前を与えることもできます。
+[`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)<!-- TODO: 日本語版のページが出来たら URL 差し替え --> で入力欄にアクセシブルな名前を与えることもできます。
 
 ```vue-html
 <label for="name">Name</label>
@@ -209,7 +209,7 @@ Chrome DevTools でこの要素を検査し、アクセシブルな名前がど�
 
 #### `aria-labelledby` {#aria-labelledby}
 
-[`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) は `aria-label` と似ていますが、ラベルテキストが画面上に表示されている場合に使用されます。他の要素とは `id` で対になっており、複数の `id` をリンクさせることができます:
+[`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)<!-- TODO: 日本語版のページが出来たら URL 差し替え --> は `aria-label` と似ていますが、ラベルテキストが画面上に表示されている場合に使用されます。他の要素とは `id` で対になっており、複数の `id` をリンクさせることができます:
 
 ```vue-html
 <form
@@ -239,7 +239,7 @@ Chrome DevTools でこの要素を検査し、アクセシブルな名前がど�
 
 #### `aria-describedby` {#aria-describedby}
 
-[aria-describedby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) は `aria-labelledby` と同じように使われますが、ユーザーが必要とするかもしれない追加の情報を含む説明を提供します。これはどのような入力欄に対しても、その基準を記述するために使用することができます:
+[aria-describedby](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby)<!-- TODO: 日本語版のページが出来たら URL 差し替え --> は `aria-labelledby` と同じように使われますが、ユーザーが必要とするかもしれない追加の情報を含む説明を提供します。これはどのような入力欄に対しても、その基準を記述するために使用することができます:
 
 ```vue-html
 <form
@@ -325,7 +325,7 @@ Chrome DevTools で検査することで、その説明文を確認すること�
 ### インストラクション {#instructions}
 
 入力フィールドにインストラクションを追加する場合は、入力欄に正しくリンクさせるようにしてください。
-インストラクションを追加し、[`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) の中に複数の id をバインドすることができます。これにより、より柔軟なデザインが可能になります。
+インストラクションを追加し、[`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)<!-- TODO: 日本語版のページが出来たら URL 差し替え --> の中に複数の id をバインドすることができます。これにより、より柔軟なデザインが可能になります。
 
 ```vue-html
 <fieldset>
@@ -341,7 +341,7 @@ Chrome DevTools で検査することで、その説明文を確認すること�
 </fieldset>
 ```
 
-または、[`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) で入力欄に説明文を付けることもできます:
+または、[`aria-describedby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby)<!-- TODO: 日本語版のページが出来たら URL 差し替え --> で入力欄に説明文を付けることもできます:
 
 ```vue-html
 <fieldset>

--- a/src/guide/essentials/event-handling.md
+++ b/src/guide/essentials/event-handling.md
@@ -254,7 +254,7 @@ methods: {
 関連するコードが同じの順番で生成されるため、修飾子を使用するときには順番は重要です。したがって、`@click.prevent.self` を使うと **要素自身とその子要素に対するクリックのデフォルトアクション** に干渉するのに対して、`@click.self.prevent` は要素自身のクリックのデフォルトアクションにのみに干渉します。
 :::
 
-`.capture`、 `.once`、 さらには `.passive` 修飾子は [ネイティブ  `addEventListener` メソッドのオプション](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#options) を反映します:
+`.capture`、 `.once`、 さらには `.passive` 修飾子は[ネイティブ  `addEventListener` メソッドのオプション](https://developer.mozilla.org/ja/docs/Web/API/EventTarget/addEventListener#options)を反映します:
 
 ```vue-html
 <!-- イベントリスナーを加えるときはキャプチャーモードを使用してください。 -->
@@ -270,7 +270,7 @@ methods: {
 <div @scroll.passive="onScroll">...</div>
 ```
 
-`.passive` 修飾子は通常、[モバイル機器のパフォーマンスの改善](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#improving_scrolling_performance_with_passive_listeners) のためのタッチイベントリスナーで使用します。
+`.passive` 修飾子は通常、[モバイル機器のパフォーマンスの改善](https://developer.mozilla.org/ja/docs/Web/API/EventTarget/addEventListener#%E3%83%91%E3%83%83%E3%82%B7%E3%83%96%E3%83%AA%E3%82%B9%E3%83%8A%E3%83%BC%E3%81%AB%E3%82%88%E3%82%8B%E3%82%B9%E3%82%AF%E3%83%AD%E3%83%BC%E3%83%AB%E3%81%AE%E6%80%A7%E8%83%BD%E6%94%B9%E5%96%84)のためのタッチイベントリスナーで使用します。
 
 ::: tip
 `.passive` と `.prevent` を一緒に使わないでください。なぜなら、`.passive` はブラウザーですでにイベントのデフォルト動作を干渉「しない」ことを示しているからです。それにより、もしそうした場合においてブラウザーが警告を出す可能性が高いからです。
@@ -285,7 +285,7 @@ methods: {
 <input @keyup.enter="submit" />
 ```
 
-[`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values) を介して公開されている有効なキーネームをケバブケースに変換されることで、直接修飾子として使用することができます。
+[`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values)<!-- TODO: 日本語版のページが出来たら URL 差し替え --> を介して公開されている有効なキーネームをケバブケースに変換されることで、直接修飾子として使用することができます。
 
 ```vue-html
 <input @keyup.page-down="onPageDown" />

--- a/src/guide/essentials/forms.md
+++ b/src/guide/essentials/forms.md
@@ -137,7 +137,7 @@ const multiSelected = ref([])
 
 </div>
 
-複数のチェックボックスを同じ配列もしくは [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) の値にバインドすることもできます:
+複数のチェックボックスを同じ配列もしくは [Set](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Set) の値にバインドすることもできます:
 
 <div class="composition-api">
 

--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -43,7 +43,7 @@ Vue は、コンポーネントのインスタンスを介して自身の組み�
 
 ### リアクティブプロキシ vs. 独自 \* {#reactive-proxy-vs-original}
 
-Vue 3 では、[JavaScript プロキシ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) を活用することで、データをリアクティブにすることができます。Vue 2 から来たユーザーは、以下のエッジケースに注意する必要があります：
+Vue 3 では、[JavaScript プロキシ](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Proxy)を活用することで、データをリアクティブにすることができます。Vue 2 から来たユーザーは、以下のエッジケースに注意する必要があります：
 
 ```js
 export default {
@@ -75,7 +75,7 @@ import { reactive } from 'vue'
 const state = reactive({ count: 0 })
 ```
 
-リアクティブなオブジェクトは [JavaScript プロキシ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) で、通常のオブジェクトと同じように振る舞います。違いは、Vue がリアクティブなオブジェクトのプロパティアクセスと変更を追跡できることです。詳細については、[Reactivity in Depth](/guide/extras/reactivity-in-depth.html) で Vue のリアクティブシステムの仕組みを説明していますが、このメインガイドを読み終えた後に読むことをお勧めします。
+リアクティブなオブジェクトは [JavaScript プロキシ](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Proxy)で、通常のオブジェクトと同じように振る舞います。違いは、Vue がリアクティブなオブジェクトのプロパティアクセスと変更を追跡できることです。詳細については、[Reactivity in Depth](/guide/extras/reactivity-in-depth.html) で Vue のリアクティブシステムの仕組みを説明していますが、このメインガイドを読み終えた後に読むことをお勧めします。
 
 こちらもご参照ください。[Typing Reactive](/guide/typescript/composition-api.html#typing-reactive) <sup class="vt-badge ts" />。
 
@@ -304,7 +304,7 @@ function mutateDeeply() {
 
 ### リアクティブプロキシ vs. 独自 \*\* {#reactive-proxy-vs-original-1}
 
-注意すべきは、`reactive()` の戻り値が、元のオブジェクトの [プロキシ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) であり、元のオブジェクトと等しくないということです：
+注意すべきは、`reactive()` の戻り値が、元のオブジェクトの[プロキシ](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Proxy)であり、元のオブジェクトと等しくないということです：
 
 ```js
 const raw = {}

--- a/src/guide/essentials/template-syntax.md
+++ b/src/guide/essentials/template-syntax.md
@@ -66,7 +66,7 @@ HTML 属性の中ではマスタッシュ構文が使えません。代わりに
 
 ### ブーリアン属性 {#boolean-attributes}
 
-[ブーリアン属性](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes)は、要素に含まれるかどうかによって「真」または「偽」の値を表す属性です。例えば、[`disabled`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled) は最も一般的に用いられるブーリアン属性の 1 つです。
+[ブーリアン属性](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#boolean-attributes)は、要素に含まれるかどうかによって「真」または「偽」の値を表す属性です。例えば、[`disabled`](https://developer.mozilla.org/ja/docs/Web/HTML/Attributes/disabled) は最も一般的に用いられるブーリアン属性の 1 つです。
 
 以下のケースでは、`v-bind` は少し特別な動作をします:
 

--- a/src/guide/scaling-up/ssr.md
+++ b/src/guide/scaling-up/ssr.md
@@ -84,7 +84,7 @@ renderToString(app).then((html) => {
 <button>1</button>
 ```
 
-[`renderToString()`](/api/ssr.html#rendertostring) は Vue アプリケーションのインスタンスを受け取り、アプリケーションでレンダリングされる HTML を解決する Promise を返します。また、[Node.js Stream API](https://nodejs.org/api/stream.html) や [Web Streams API](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) を用いて、ストリームレンダリングもできます。詳しくは [SSR API リファレンス](/api/ssr.html)を参照してください。
+[`renderToString()`](/api/ssr.html#rendertostring) は Vue アプリケーションのインスタンスを受け取り、アプリケーションでレンダリングされる HTML を解決する Promise を返します。また、[Node.js Stream API](https://nodejs.org/api/stream.html) や [Web Streams API](https://developer.mozilla.org/ja/docs/Web/API/Streams_API) を用いて、ストリームレンダリングもできます。詳しくは [SSR API リファレンス](/api/ssr.html)を参照してください。
 
 そして、Vue SSR のコードをサーバーのリクエストハンドラーに移動させ、アプリケーションのマークアップをフルページの HTML でラップすることができます。次のステップでは [`express`](https://expressjs.com/) を使用します:
 


### PR DESCRIPTION
resolve #1026

英語版のリンクのままになっている箇所を `en-US` → `ja` に差し替え。
日本語版のページがない場合は TODO コメントを追加