### PR TITLE
docs: fix Prop interface type error in example

Existing code snippet gives this error:

    Default export of the module has or is using private name 'Props'.ts (4082)

Error fixed thanks to:
https://github.com/johnsoncodehk/volar/issues/1232#issue-1213615569 (#1140)

### DIFF
--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -40,12 +40,14 @@ type-base declaration と runtime declaration の両方を同時に使用する�
 props の型をインターフェースとして分離することもできます:
 
 ```vue
-<script setup lang="ts">
+<script lang="ts">
 interface Props {
   foo: string
   bar?: number
 }
+</script>
 
+<script setup lang="ts">
 const props = defineProps<Props>()
 </script>
 ```


### PR DESCRIPTION
resolves #1140
Cherry picked from https://github.com/vuejs/docs/commit/dd57dce53f0d2d62c18a5ff4e89cfe9abfeb5137