### PR TITLE
fix: enable Vercel's cleanUrls options to avoid redirection issue

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -24,5 +24,6 @@
       "source": "/v2/:path*",
       "destination": "https://v2.ja.vuejs.org/v2/:path*"
     }
-  ]
+  ],
+  "cleanUrls": true
 }


### PR DESCRIPTION
## Description of Problem
When no extension is used, page is broken with redirection: https://ja.vuejs.org/guide/introduction

## Proposed Solution

Suggested by Evan You in private: vuejs.org uses Netlify with `cleanUrls` enabled.
Enabling it is solving the issue.
