### PR TITLE
Fix indentation in events.md

### DIFF
--- a/src/guide/components/events.md
+++ b/src/guide/components/events.md
@@ -211,8 +211,8 @@ const emit = defineEmits<{
 export default {
   emits: {
     submit(payload) {
-    // バリデーションの合格/不合格を示す
-    // `true` または `false` を返す
+      // バリデーションの合格/不合格を示す
+      // `true` または `false` を返す
     }
   }
 }


### PR DESCRIPTION
https://ja.vuejs.org/guide/components/events.html#declaring-emitted-events においてインデントが適切でない箇所があったため、修正しました。