### PR TITLE
Styles: Responsive for Preference Switch

* Padding on options preferences for max-width:960px

* New padding em

* 959px and no units

* Delete package-lock.json

* Update .vitepress/theme/components/PreferenceSwitch.vue

Co-authored-by: skirtle <65301168+skirtles-code@users.noreply.github.com>

---------

Co-authored-by: skirtle <65301168+skirtles-code@users.noreply.github.com> (#1269)

### DIFF
--- a/.vitepress/theme/components/PreferenceSwitch.vue
+++ b/.vitepress/theme/components/PreferenceSwitch.vue
@@ -168,7 +168,13 @@ function useToggleFn(
 
 .switch-container {
   display: flex;
-  align-items: center;
+  align-items: center;  
+}
+
+@media(max-width: 959px){
+  .switch-container {
+    padding: 0 1em;
+  }
 }
 
 .switch-container:nth-child(2) {


### PR DESCRIPTION
resolves #1269
Cherry picked from https://github.com/vuejs/docs/commit/127093f65da49a8e6f5bddc7ad40cb788151e0fb