### PR TITLE
CI 設定変更

### DIFF
--- a/.github/workflows/ja.yaml
+++ b/.github/workflows/ja.yaml
@@ -1,6 +1,10 @@
 name: textlint
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   textlint:
@@ -8,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: 18
     - name: Install deps
       run: npx pnpm i
     - name: Run textlint

--- a/.github/workflows/ja.yaml
+++ b/.github/workflows/ja.yaml
@@ -16,6 +16,7 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: 18
+    - run: corepack enable pnpm
     - name: Install deps
       run: npx pnpm i
     - name: Run textlint


### PR DESCRIPTION
textlint の GitHub Action が下記のエラーになっているので、Node 18 を使うように設定を変更しました

> Run npx pnpm i
npx: installed 1 in 1.591s
ERROR: This version of pnpm requires at least Node.js v16.1[4](https://github.com/vuejs-translations/docs-ja/actions/runs/4565082028/jobs/8055691799#step:4:5)
The current version of Node.js is v14.21.3