### PR TITLE
docs: change the outdated option for end-to-end testing

The latest version (`3.6.1`) of `create-vue` allows to select the end-to-end testing framework, suggesting 2 options: Cypress and Playwright (#1330)

### DIFF
--- a/src/guide/built-ins/transition-demos/ListStagger.vue
+++ b/src/guide/built-ins/transition-demos/ListStagger.vue
@@ -13,7 +13,7 @@ const list = [
 const query = ref('')
 
 const computedList = computed(() => {
-  return list.filter((item) => item.msg.toLowerCase().includes(query.value))
+  return list.filter((item) => item.msg.toLowerCase().includes(query.value.toLowerCase()))
 })
 
 function onBeforeEnter(el) {

--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -34,7 +34,7 @@ footer: false
 <span style="color:var(--vt-c-green);">✔</span> <span style="color:#A6ACCD;">Add Vue Router for Single Page Application development? <span style="color:#888;">… <span style="color:#89DDFF;text-decoration:underline">No</span> / Yes</span></span>
 <span style="color:var(--vt-c-green);">✔</span> <span style="color:#A6ACCD;">Add Pinia for state management? <span style="color:#888;">… <span style="color:#89DDFF;text-decoration:underline">No</span> / Yes</span></span>
 <span style="color:var(--vt-c-green);">✔</span> <span style="color:#A6ACCD;">Add Vitest for Unit testing? <span style="color:#888;">… <span style="color:#89DDFF;text-decoration:underline">No</span> / Yes</span></span>
-<span style="color:var(--vt-c-green);">✔</span> <span style="color:#A6ACCD;">Add Cypress for both Unit and End-to-End testing? <span style="color:#888;">… <span style="color:#89DDFF;text-decoration:underline">No</span> / Yes</span></span>
+<span style="color:var(--vt-c-green);">✔</span> <span style="color:#A6ACCD;">Add an End-to-End Testing Solution? <span style="color:#888;">… <span style="color:#89DDFF;text-decoration:underline">No</span> / Cypress / Playwright</span></span>
 <span style="color:var(--vt-c-green);">✔</span> <span style="color:#A6ACCD;">Add ESLint for code quality? <span style="color:#888;">… <span style="color:#89DDFF;text-decoration:underline">No</span> / Yes</span></span>
 <span style="color:var(--vt-c-green);">✔</span> <span style="color:#A6ACCD;">Add Prettier for code formatting? <span style="color:#888;">… <span style="color:#89DDFF;text-decoration:underline">No</span> / Yes</span></span>
 <span></span>


### PR DESCRIPTION
resolves #1330
Cherry picked from https://github.com/vuejs/docs/commit/b778c75189fc55352e7b543b5a15c7c9df9084cb