### PR TITLE
docs: use semantically correct tag for date

It's more semantically correct to use `<time>` tag instead of `<span>` for dates (#1354)

### DIFF
--- a/src/guide/essentials/template-syntax.md
+++ b/src/guide/essentials/template-syntax.md
@@ -151,9 +151,9 @@ Vue のテンプレートでは、以下の場所で JavaScript の式を使用�
 コンポーネントから公開されているメソッドであれば、以下のようにバインディングの式の内部で呼び出すことができます:
 
 ```vue-html
-<span :title="toTitleDate(date)">
+<time :title="toTitleDate(date)" :datetime="date">
   {{ formatDate(date) }}
-</span>
+</time>
 ```
 
 :::tip


### PR DESCRIPTION
resolves #1354
Cherry picked from https://github.com/vuejs/docs/commit/67067a1f265e51a5068dc91f9ce470eb5e3e48a5