### PR TITLE
use onBeforeUnmount in useEventListener

use `onBeforeUnmount` in `useEventListener` instead of `onUnmounted` since `onUnmounted will not work if you trying to pass some element ref from the consumer component.
Using the  `onUnmounted` the ref will be null since the component is unmounted, so we should use `onBeforeUnmount` (#1356)

### DIFF
--- a/src/guide/essentials/template-syntax.md
+++ b/src/guide/essentials/template-syntax.md
@@ -151,9 +151,9 @@ Vue のテンプレートでは、以下の場所で JavaScript の式を使用�
 コンポーネントから公開されているメソッドであれば、以下のようにバインディングの式の内部で呼び出すことができます:
 
 ```vue-html
-<span :title="toTitleDate(date)">
+<time :title="toTitleDate(date)" :datetime="date">
   {{ formatDate(date) }}
-</span>
+</time>
 ```
 
 :::tip

--- a/src/guide/reusability/composables.md
+++ b/src/guide/reusability/composables.md
@@ -94,13 +94,13 @@ const { x, y } = useMouse()
 
 ```js
 // event.js
-import { onMounted, onUnmounted } from 'vue'
+import { onMounted, onBeforeUnmount } from 'vue'
 
 export function useEventListener(target, event, callback) {
   // 必要であれば、 セレクター文字列を target として
   // 扱えるようにもできます
   onMounted(() => target.addEventListener(event, callback))
-  onUnmounted(() => target.removeEventListener(event, callback))
+  onBeforeUnmount(() => target.removeEventListener(event, callback))
 }
 ```
 


### PR DESCRIPTION
resolves #1356
Cherry picked from https://github.com/vuejs/docs/commit/30cb9d99d9f9b8917604bdf623da4199f6505bca