### PR TITLE
examples (todomvc): change `@vnode-mounted` to `@vue:mounted`

This example was using a deprecated API (`@vnode-mounted`), so I updated it. (#1488)

### DIFF
--- a/src/examples/src/todomvc/App/template.html
+++ b/src/examples/src/todomvc/App/template.html
@@ -34,7 +34,7 @@
           class="edit"
           type="text"
           v-model="todo.title"
-          @vnode-mounted="({ el }) => el.focus()"
+          @vue:mounted="({ el }) => el.focus()"
           @blur="doneEdit(todo)"
           @keyup.enter="doneEdit(todo)"
           @keyup.escape="cancelEdit(todo)"


### PR DESCRIPTION
resolves #1488
Cherry picked from https://github.com/vuejs/docs/commit/9c34f13852e0ed31095f2f67e00d48f45f26877f