### PR TITLE
docs: use `npm create` instead of `npm init`

For consistency across package managers.

`yarn` and `pnpm` only support the `create` subcommand.
`init` means something different for them.

So using `create` leads to the least confusion if the user is using
multiple package managers. (#1515)

### DIFF
--- a/src/guide/quick-start.md
+++ b/src/guide/quick-start.md
@@ -24,7 +24,7 @@ footer: false
 
 [Node.js](https://nodejs.org/) の最新バージョンがインストールされていること、現在の作業ディレクトリがプロジェクトを作成する予定の場所であることを確認し、コマンドラインで次のコマンドを（`>` 記号なしで）実行します:
 
-<div class="language-sh"><pre><code><span class="line"><span style="color:var(--vt-c-green);">&gt;</span> <span style="color:#A6ACCD;">npm init vue@latest</span></span></code></pre></div>
+<div class="language-sh"><pre><code><span class="line"><span style="color:var(--vt-c-green);">&gt;</span> <span style="color:#A6ACCD;">npm create vue@latest</span></span></code></pre></div>
 
 このコマンドは、公式の Vue プロジェクトスキャフォールディングツールである [create-vue](https://github.com/vuejs/create-vue) をインストールして実行します。TypeScript やテストのサポートなど、いくつかのオプション機能がプロンプトに表示されます:
 

--- a/src/guide/scaling-up/tooling.md
+++ b/src/guide/scaling-up/tooling.md
@@ -21,7 +21,7 @@ Vue の SFC を試すためにマシンに何かをインストールする必�
 
 Vite + Vue で始めるには、以下を実行するだけです:
 
-<div class="language-sh"><pre><code><span class="line"><span style="color:var(--vt-c-green);">$</span> <span style="color:#A6ACCD;">npm init vue@latest</span></span></code></pre></div>
+<div class="language-sh"><pre><code><span class="line"><span style="color:var(--vt-c-green);">$</span> <span style="color:#A6ACCD;">npm create vue@latest</span></span></code></pre></div>
 
 このコマンドは、Vue 公式の雛形作成 (scaffolding) ツールである [create-vue](https://github.com/vuejs/create-vue) をインストールして実行します。
 


### PR DESCRIPTION
resolves #1515
Cherry picked from https://github.com/vuejs/docs/commit/5c3fd4b6c3caeab2d5c374cf97d467ad26a427ad