### PR TITLE
Update v-model.md naming convention

* Update v-model.md naming convention

kebab-case should be used when event is being listened to inside parent's template.

* Update v-model.md (#1559)

### DIFF
--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -21,8 +21,8 @@
 
 ```vue-html
 <CustomInput
-  :modelValue="searchText"
-  @update:modelValue="newValue => searchText = newValue"
+  :model-value="searchText"
+  @update:model-value="newValue => searchText = newValue"
 />
 ```
 


### PR DESCRIPTION
resolves #1559
Cherry picked from https://github.com/vuejs/docs/commit/7f299d98443efc489115d5f6b64d02094660dbd0