### PR TITLE
Update built-in-components.md rename <teleport> to <Teleport>

I think teleport component name should be capitalized. Sincere sorry if I'm wrong. (#1588)

### DIFF
--- a/src/api/built-in-components.md
+++ b/src/api/built-in-components.md
@@ -294,17 +294,17 @@ h(Transition, {
   ターゲットコンテナーの指定:
 
   ```vue-html
-  <teleport to="#some-id" />
-  <teleport to=".some-class" />
-  <teleport to="[data-teleport]" />
+  <Teleport to="#some-id" />
+  <Teleport to=".some-class" />
+  <Teleport to="[data-teleport]" />
   ```
 
   条件によって無効化:
 
   ```vue-html
-  <teleport to="#popup" :disabled="displayVideoInline">
+  <Teleport to="#popup" :disabled="displayVideoInline">
     <video src="./my-movie.mp4">
-  </teleport>
+  </Teleport>
   ```
 
 - **参照** [ガイド - Teleport](/guide/built-ins/teleport)


### PR DESCRIPTION
resolves #1588
Cherry picked from https://github.com/vuejs/docs/commit/7d93d280bb4d014037ab523bad39d5bd5f930caf