### PR TITLE
fix syntax highlight for vitepress rc.31 shijiki migration (#1661)

### DIFF
--- a/.vitepress/theme/styles/index.css
+++ b/.vitepress/theme/styles/index.css
@@ -5,8 +5,7 @@
 @import "./utilities.css";
 @import "./style-guide.css";
 
-/* bugfix: https://github.com/vuejs/theme/pull/95 */
-
-.vt-flyout-menu {
-  max-height: calc(100vh - var(--vt-nav-height) - var(--vt-banner-height, 0px)) !important;
+/* vitepress rc.31 migrated to shijiki and need this to apply code styles */
+.vp-code span {
+  color: var(--shiki-dark, inherit);
 }


### PR DESCRIPTION
resolves #1661
Cherry picked from https://github.com/vuejs/docs/commit/b2bca5567e0e65ed7b5e365427fafa9e5a4e416d