### PR TITLE
chore(deps): bump @vue/repl from 3.0.1 to 3.1.0

Bumps [@vue/repl](https://github.com/vuejs/repl) from 3.0.1 to 3.1.0.
- [Release notes](https://github.com/vuejs/repl/releases)
- [Changelog](https://github.com/vuejs/repl/blob/main/CHANGELOG.md)
- [Commits](https://github.com/vuejs/repl/compare/v3.0.1...v3.1.0)

---
updated-dependencies:
- dependency-name: "@vue/repl"
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com> (#1730)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
 dependencies:
   '@vue/repl':
     specifier: ^3.0.0
-    version: 3.0.1
+    version: 3.1.0
   '@vue/theme':
     specifier: ^2.2.5
     version: 2.2.5(vitepress@1.0.0-rc.31)(vue@3.4.0-beta.2)
@@ -1119,8 +1119,8 @@ packages:
       '@vue/shared': 3.4.0-beta.2
     dev: false
 
-  /@vue/repl@3.0.1:
-    resolution: {integrity: sha512-o3/0bVx8n70BZ+OD/r3KMuWuUR93zA99YtXOtTAKYMYvHf18DfdQt7n1wyIaOgXwK1HwTfUYWJA261Wdyh+U2Q==}
+  /@vue/repl@3.1.0:
+    resolution: {integrity: sha512-lnR010NTkysg71Z0TVsFCTfiF5ARZbyohqymGpOxOrSuSI4o9RlSvWH6YmJdv9OHm5j69HKLVVUhXlCScMCQrg==}
     dev: false
 
   /@vue/runtime-core@3.3.12:


### PR DESCRIPTION
resolves #1730
Cherry picked from https://github.com/vuejs/docs/commit/6dea6b88dd53682835fadb50393d6dd65f3be13b