### PR TITLE
chore(deps): bump @vue/repl from 3.3.0 to 3.4.0

Bumps [@vue/repl](https://github.com/vuejs/repl) from 3.3.0 to 3.4.0.
- [Release notes](https://github.com/vuejs/repl/releases)
- [Changelog](https://github.com/vuejs/repl/blob/v3.4.0/CHANGELOG.md)
- [Commits](https://github.com/vuejs/repl/compare/v3.3.0...v3.4.0)

---
updated-dependencies:
- dependency-name: "@vue/repl"
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com> (#1827)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
 dependencies:
   '@vue/repl':
     specifier: ^3.0.0
-    version: 3.3.0
+    version: 3.4.0
   '@vue/theme':
     specifier: ^2.2.5
     version: 2.2.5(vitepress@1.0.0-rc.33)(vue@3.4.11)
@@ -1054,8 +1054,8 @@ packages:
       '@vue/shared': 3.4.11
     dev: false
 
-  /@vue/repl@3.3.0:
-    resolution: {integrity: sha512-A9tdO7obt/kpFUHdgGoRnan6bZjfz/WAJ5+DpPkvgNEc960W+bJraURv8MUVtH2Id/byWotKbUve2jTakiccSw==}
+  /@vue/repl@3.4.0:
+    resolution: {integrity: sha512-iHhIsmQsp9PJuOwverCRQC2owFb0FSFzk6YWwyirAX6AqH//2FrUV4WB16f9lGX5pDXAHjxlzAE6Lqf9P17HHA==}
     dev: false
 
   /@vue/runtime-core@3.4.11:


### PR DESCRIPTION
resolves #1827
Cherry picked from https://github.com/vuejs/docs/commit/64a9c488eef86bd6a24bf1520ebfa0febdde7ca9