### PR TITLE
docs: fix typo - prevNode should be prevVnode

### DIFF
--- a/src/guide/reusability/custom-directives.md
+++ b/src/guide/reusability/custom-directives.md
@@ -147,7 +147,7 @@ const myDirective = {
   - `dir`: ディレクティブ定義オブジェクト。
 
 - `vnode`: バインドされた要素を表す基礎となる VNode。
-- `prevNode`: 前のレンダリングからバインドされた要素を表す VNode。`beforeUpdate` と `updated` フックでのみ利用可能です。
+- `prevVnode`: 前のレンダリングからバインドされた要素を表す VNode。`beforeUpdate` と `updated` フックでのみ利用可能です。
 
 例として、次のようなディレクティブの使い方を考えてみましょう:
 


### PR DESCRIPTION
resolve #1910
https://github.com/vuejs/docs/commit/a8cf7bf44ada19452c765a1958753adf0d398e99
の修正になります。
ご確認お願いします 🙏 
