### PR TITLE
docs: ensure consistency in example for class-and-style.md

In the inline style are it was written 13 px instead of 30px for the font size. I re write it to 30px (#2007)

### DIFF
--- a/.vitepress/theme/styles/inline-demo.css
+++ b/.vitepress/theme/styles/inline-demo.css
@@ -12,8 +12,8 @@
   border: 2px solid var(--vt-c-green);
   margin-right: 8px;
   margin-left: 4px;
-  line-height: 15px;
-  padding-left: 4.5px;
+  line-height: 16px;
+  padding-left: 4.2px;
   font-size: 11px;
 }
 

--- a/src/guide/essentials/class-and-style.md
+++ b/src/guide/essentials/class-and-style.md
@@ -296,7 +296,7 @@ CSS プロパティのキーにはキャメルケース（camelCase）が推奨�
 ```js
 const styleObject = reactive({
   color: 'red',
-  fontSize: '13px'
+  fontSize: '30px'
 })
 ```
 


### PR DESCRIPTION
resolves #2007
Cherry picked from https://github.com/vuejs/docs/commit/3cfa6784b313ab8bcca53b07887b83ef57d28aba