### PR TITLE
fix: `<pre>` inside `<p>` in example code

Co-authored-by: Divyansh Singh <40380293+brc-dd@users.noreply.github.com> (#2017)

### DIFF
--- a/src/examples/src/form-bindings/App/template.html
+++ b/src/examples/src/form-bindings/App/template.html
@@ -1,5 +1,6 @@
 <h2>Text Input</h2>
-<input v-model="text"> {{ text }}
+<input v-model="text">
+<p>{{ text }}</p>
 
 <h2>Checkbox</h2>
 <input type="checkbox" id="checkbox" v-model="checked">
@@ -16,7 +17,7 @@
 <label for="john">John</label>
 <input type="checkbox" id="mike" value="Mike" v-model="checkedNames">
 <label for="mike">Mike</label>
-<p>Checked names: <pre>{{ checkedNames }}</pre></p>
+<p>Checked names: {{ checkedNames }}</p>
 
 <h2>Radio</h2>
 <input type="radio" id="one" value="One" v-model="picked">
@@ -24,8 +25,7 @@
 <br>
 <input type="radio" id="two" value="Two" v-model="picked">
 <label for="two">Two</label>
-<br>
-<span>Picked: {{ picked }}</span>
+<p>Picked: {{ picked }}</p>
 
 <h2>Select</h2>
 <select v-model="selected">
@@ -34,7 +34,7 @@
   <option>B</option>
   <option>C</option>
 </select>
-<span>Selected: {{ selected }}</span>
+<p>Selected: {{ selected }}</p>
 
 <h2>Multi Select</h2>
 <select v-model="multiSelected" multiple style="width:100px">
@@ -42,4 +42,4 @@
   <option>B</option>
   <option>C</option>
 </select>
-<span>Selected: {{ multiSelected }}</span>
+<p>Selected: {{ multiSelected }}</p>

--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -547,7 +547,7 @@ const [firstName, firstNameModifiers] = defineModel('firstName')
 const [lastName, lastNameModifiers] = defineModel('lastName')
 
 console.log(firstNameModifiers) // { capitalize: true }
-console.log(lastNameModifiers) // { uppercase: true}
+console.log(lastNameModifiers) // { uppercase: true }
 </script>
 ```
 
@@ -565,7 +565,7 @@ lastNameModifiers: { default: () => ({}) }
 defineEmits(['update:firstName', 'update:lastName'])
 
 console.log(props.firstNameModifiers) // { capitalize: true }
-console.log(props.lastNameModifiers) // { uppercase: true}
+console.log(props.lastNameModifiers) // { uppercase: true }
 </script>
 ```
 


### PR DESCRIPTION
resolves #2017
Cherry picked from https://github.com/vuejs/docs/commit/7d474410c53ae40cd84be1c17cbfa644f534f974