### PR TITLE
chore(deps): bump @vue/repl from 4.1.1 to 4.1.2

Bumps [@vue/repl](https://github.com/vuejs/repl) from 4.1.1 to 4.1.2.
- [Release notes](https://github.com/vuejs/repl/releases)
- [Changelog](https://github.com/vuejs/repl/blob/main/CHANGELOG.md)
- [Commits](https://github.com/vuejs/repl/compare/v4.1.1...v4.1.2)

---
updated-dependencies:
- dependency-name: "@vue/repl"
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com> (#2025)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
 dependencies:
   '@vue/repl':
     specifier: ^4.0.1
-    version: 4.1.1
+    version: 4.1.2
   '@vue/theme':
     specifier: ^2.2.5
     version: 2.2.5(vitepress@1.1.0)(vue@3.4.23)
@@ -1116,8 +1116,8 @@ packages:
       '@vue/shared': 3.4.23
     dev: false
 
-  /@vue/repl@4.1.1:
-    resolution: {integrity: sha512-gkbnU+rM01/ILdnDJbsWS8+PW6qMAzprBo/U2+7eVci0kx6VAR26fL/qrcEPwEYa6q0vzzptZ4il0SaUGGqZKw==}
+  /@vue/repl@4.1.2:
+    resolution: {integrity: sha512-h5JQ5NRN9HOCNfE4QCbZsFgAFS7/A21V3zrltxV2Uag1JIvtQb68qfmj795CPFjMBnRNpCddOBi34AKlq5yHbg==}
     dev: false
 
   /@vue/runtime-core@3.4.23:


### PR DESCRIPTION
resolves #2025
Cherry picked from https://github.com/vuejs/docs/commit/0112f1aa6a5709f3c5d7d711369c4e992cecbf60