### PR TITLE
docs: fix a typo

### DIFF
--- a/src/guide/built-ins/keep-alive.md
+++ b/src/guide/built-ins/keep-alive.md
@@ -60,7 +60,7 @@ import SwitchComponent from './keep-alive-demos/SwitchComponent.vue'
   <component :is="view" />
 </KeepAlive>
 
-<!-- 正義表現（`v-bind` を使用）-->
+<!-- 正規表現（`v-bind` を使用）-->
 <KeepAlive :include="/a|b/">
   <component :is="view" />
 </KeepAlive>


### PR DESCRIPTION
"正義表現" -> "正規表現"