### PR TITLE
chore(deps): bump vitepress from 1.1.3 to 1.1.4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ dependencies:
     version: 4.1.2
   '@vue/theme':
     specifier: ^2.2.5
-    version: 2.2.5(vitepress@1.1.3)(vue@3.4.25)
+    version: 2.2.5(vitepress@1.1.4)(vue@3.4.25)
   dynamics.js:
     specifier: ^1.1.5
     version: 1.1.5
@@ -22,7 +22,7 @@ dependencies:
     version: 3.9.0
   vitepress:
     specifier: ^1.1.0
-    version: 1.1.3(@types/node@20.10.1)(terser@5.14.2)
+    version: 1.1.4(@types/node@20.10.1)(terser@5.14.2)
   vue:
     specifier: ^3.4.0
     version: 3.4.25
@@ -1149,7 +1149,7 @@ packages:
     resolution: {integrity: sha512-k0yappJ77g2+KNrIaF0FFnzwLvUBLUYr8VOwz+/6vLsmItFp51AcxLL7Ey3iPd7BIRyWPOcqUjMnm7OkahXllA==}
     dev: false
 
-  /@vue/theme@2.2.5(vitepress@1.1.3)(vue@3.4.25):
+  /@vue/theme@2.2.5(vitepress@1.1.4)(vue@3.4.25):
     resolution: {integrity: sha512-UUPD0XxlRa69Ytely8JEU/cu8Pae5f4UqZNIXANPN8KT6j/O23dCbOfp1cKlSn+Q/xXLYp0K+vRh4IqZjt/9BQ==}
     peerDependencies:
       vitepress: ^1.0.0-alpha.60
@@ -1159,7 +1159,7 @@ packages:
       '@vueuse/core': 9.13.0(vue@3.4.25)
       body-scroll-lock: 3.1.5
       normalize.css: 8.0.1
-      vitepress: 1.1.3(@types/node@20.10.1)(terser@5.14.2)
+      vitepress: 1.1.4(@types/node@20.10.1)(terser@5.14.2)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/react'
@@ -3701,8 +3701,8 @@ packages:
       fsevents: 2.3.3
     dev: false
 
-  /vitepress@1.1.3(@types/node@20.10.1)(terser@5.14.2):
-    resolution: {integrity: sha512-hGrIYN0w9IHWs0NQSnlMjKV/v/HLfD+Ywv5QdvCSkiT32mpNOOwUrZjnqZv/JL/WBPpUc94eghTUvmipxw0xrA==}
+  /vitepress@1.1.4(@types/node@20.10.1)(terser@5.14.2):
+    resolution: {integrity: sha512-bWIzFZXpPB6NIDBuWnS20aMADH+FcFKDfQNYFvbOWij03PR29eImTceQHIzCKordjXYBhM/TjE5VKFTUJ3EheA==}
     hasBin: true
     peerDependencies:
       markdown-it-mathjax3: ^4


### PR DESCRIPTION
resolve #2035 

vuejs/docs@baf27c8 の反映です