### PR TITLE
fix: correctly link to i18n custom blocks (#2105)

### DIFF
--- a/src/api/sfc-spec.md
+++ b/src/api/sfc-spec.md
@@ -66,7 +66,7 @@ export default {
 
 - [Gridsome: `<page-query>`](https://gridsome.org/docs/querying-data/)
 - [vite-plugin-vue-gql: `<gql>`](https://github.com/wheatjs/vite-plugin-vue-gql)
-- [vue-i18n: `<i18n>`](https://github.com/intlify/bundle-tools/tree/main/packages/vite-plugin-vue-i18n#i18n-custom-block)
+- [vue-i18n: `<i18n>`](https://github.com/intlify/bundle-tools/tree/main/packages/unplugin-vue-i18n#i18n-custom-block)
 
 カスタムブロックの扱いはツールに依存します - 独自のカスタムブロック統合を構築したい場合は、[SFC カスタムブロック統合ツールのセクション](/guide/scaling-up/tooling#sfc-custom-block-integrations)で詳細を確認してください。
 


### PR DESCRIPTION
resolves #2105
Cherry picked from https://github.com/vuejs/docs/commit/7493b263972c078e39db3b3e4b41ac3e01f5f539