### PR TITLE
chore(deps): bump vitepress from 1.3.1 to 1.3.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 4.3.1
       '@vue/theme':
         specifier: ^2.2.12
-        version: 2.2.12(@algolia/client-search@4.20.0)(search-insights@2.14.0)(vitepress@1.3.1(@algolia/client-search@4.20.0)(@types/node@20.14.2)(postcss@8.4.41)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.4.5))(vue@3.4.35(typescript@5.4.5))
+        version: 2.2.12(@algolia/client-search@4.20.0)(search-insights@2.14.0)(vitepress@1.3.2(@algolia/client-search@4.20.0)(@types/node@20.14.2)(postcss@8.4.41)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.4.5))(vue@3.4.35(typescript@5.4.5))
       dynamics.js:
         specifier: ^1.1.5
         version: 1.1.5
@@ -22,7 +22,7 @@ importers:
         version: 3.12.5
       vitepress:
         specifier: ^1.2.3
-        version: 1.3.1(@algolia/client-search@4.20.0)(@types/node@20.14.2)(postcss@8.4.41)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.4.5)
+        version: 1.3.2(@algolia/client-search@4.20.0)(@types/node@20.14.2)(postcss@8.4.41)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.4.5)
       vue:
         specifier: ^3.4.27
         version: 3.4.35(typescript@5.4.5)
@@ -554,9 +554,6 @@ packages:
     resolution: {integrity: sha512-iZ0e/u9mRE4T8tNhlo0tbA+gzVkgv8r5BX6s1kRbOZqfpq14qoIvCZ5gIgraOmYkMYrSEZgkkojFPr+Nyq/Mnw==}
     peerDependencies:
       vue: 3.4.35
-
-  '@vue/shared@3.4.32':
-    resolution: {integrity: sha512-ep4mF1IVnX/pYaNwxwOpJHyBtOMKWoKZMbnUyd+z0udqIxLUh7YCCd/JfDna8aUrmnG9SFORyIq2HzEATRrQsg==}
 
   '@vue/shared@3.4.35':
     resolution: {integrity: sha512-hvuhBYYDe+b1G8KHxsQ0diDqDMA8D9laxWZhNAjE83VZb5UDaXl9Xnz7cGdDSyiHM90qqI/CyGMcpBpiDy6VVQ==}
@@ -1517,10 +1514,6 @@ packages:
   pluralize@2.0.0:
     resolution: {integrity: sha1-crcmqm+sHt7uQiVsfY3CVrM1Z38=}
 
-  postcss@8.4.39:
-    resolution: {integrity: sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.4.41:
     resolution: {integrity: sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1984,8 +1977,8 @@ packages:
       terser:
         optional: true
 
-  vitepress@1.3.1:
-    resolution: {integrity: sha512-soZDpg2rRVJNIM/IYMNDPPr+zTHDA5RbLDHAxacRu+Q9iZ2GwSR0QSUlLs+aEZTkG0SOX1dc8RmUYwyuxK8dfQ==}
+  vitepress@1.3.2:
+    resolution: {integrity: sha512-6gvecsCuR6b1Cid4w19KQiQ02qkpgzFRqiG0v1ZBekGkrZCzsxdDD5y4WH82HRXAOhU4iZIpzA1CsWqs719rqA==}
     hasBin: true
     peerDependencies:
       markdown-it-mathjax3: ^4
@@ -2603,11 +2596,9 @@ snapshots:
       '@vue/shared': 3.4.35
       vue: 3.4.35(typescript@5.4.5)
 
-  '@vue/shared@3.4.32': {}
-
   '@vue/shared@3.4.35': {}
 
-  '@vue/theme@2.2.12(@algolia/client-search@4.20.0)(search-insights@2.14.0)(vitepress@1.3.1(@algolia/client-search@4.20.0)(@types/node@20.14.2)(postcss@8.4.41)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.4.5))(vue@3.4.35(typescript@5.4.5))':
+  '@vue/theme@2.2.12(@algolia/client-search@4.20.0)(search-insights@2.14.0)(vitepress@1.3.2(@algolia/client-search@4.20.0)(@types/node@20.14.2)(postcss@8.4.41)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.4.5))(vue@3.4.35(typescript@5.4.5))':
     dependencies:
       '@docsearch/css': 3.6.0
       '@docsearch/js': 3.6.0(@algolia/client-search@4.20.0)(search-insights@2.14.0)
@@ -2615,7 +2606,7 @@ snapshots:
       body-scroll-lock: 4.0.0-beta.0
       normalize.css: 8.0.1
       tiny-decode: 0.1.3
-      vitepress: 1.3.1(@algolia/client-search@4.20.0)(@types/node@20.14.2)(postcss@8.4.41)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.4.5)
+      vitepress: 1.3.2(@algolia/client-search@4.20.0)(@types/node@20.14.2)(postcss@8.4.41)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.4.5)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/react'
@@ -3607,12 +3598,6 @@ snapshots:
 
   pluralize@2.0.0: {}
 
-  postcss@8.4.39:
-    dependencies:
-      nanoid: 3.3.7
-      picocolors: 1.0.1
-      source-map-js: 1.2.0
-
   postcss@8.4.41:
     dependencies:
       nanoid: 3.3.7
@@ -4210,14 +4195,14 @@ snapshots:
   vite@5.3.3(@types/node@20.14.2)(terser@5.31.0):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.39
+      postcss: 8.4.41
       rollup: 4.13.1
     optionalDependencies:
       '@types/node': 20.14.2
       fsevents: 2.3.3
       terser: 5.31.0
 
-  vitepress@1.3.1(@algolia/client-search@4.20.0)(@types/node@20.14.2)(postcss@8.4.41)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.4.5):
+  vitepress@1.3.2(@algolia/client-search@4.20.0)(@types/node@20.14.2)(postcss@8.4.41)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.4.5):
     dependencies:
       '@docsearch/css': 3.6.0
       '@docsearch/js': 3.6.0(@algolia/client-search@4.20.0)(search-insights@2.14.0)
@@ -4226,7 +4211,7 @@ snapshots:
       '@types/markdown-it': 14.1.1
       '@vitejs/plugin-vue': 5.0.5(vite@5.3.3(@types/node@20.14.2)(terser@5.31.0))(vue@3.4.35(typescript@5.4.5))
       '@vue/devtools-api': 7.3.5
-      '@vue/shared': 3.4.32
+      '@vue/shared': 3.4.35
       '@vueuse/core': 10.11.0(vue@3.4.35(typescript@5.4.5))
       '@vueuse/integrations': 10.11.0(focus-trap@7.5.4)(vue@3.4.35(typescript@5.4.5))
       focus-trap: 7.5.4


### PR DESCRIPTION
resolve #2214

vuejs/docs@1113c8a の反映です