### PR TITLE
docs: missed return value type for useModel() (#2300)

### DIFF
--- a/src/api/composition-api-helpers.md
+++ b/src/api/composition-api-helpers.md
@@ -35,12 +35,17 @@ TypeScript を使用する場合は、代わりに [`defineSlots()`](/api/sfc-sc
     props: Record<string, any>,
     key: string,
     options?: DefineModelOptions
-  )
+  ): ModelRef
 
   type DefineModelOptions<T = any> = {
     get?: (v: T) => any
     set?: (v: T) => any
   }
+
+  type ModelRef<T, M extends PropertyKey = string, G = T, S = T> = Ref<G, S> & [
+    ModelRef<T, M, G, S>,
+    Record<M, true | undefined>
+]
   ```
 
 - **例**


### PR DESCRIPTION
resolves #2300
Cherry picked from https://github.com/vuejs/docs/commit/e20eb77a4ef3e0c32c081be7190cb861400c37ff