### PR TITLE
docs: update heading level for Generics section

### DIFF
--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -479,7 +479,7 @@ const post = await fetch(`/api/post/1`).then((r) => r.json())
 `async setup()` は、現在まだ実験的な機能である [`Suspense`](/guide/built-ins/suspense.html) と組み合わせて使用する必要があります。将来のリリースで完成させてドキュメント化する予定ですが、もし今興味があるのであれば、その[テスト](https://github.com/vuejs/core/blob/main/packages/runtime-core/__tests__/components/Suspense.spec.ts)を参照することで、どのように動作するかを確認できます。
 :::
 
-### ジェネリクス <sup class="vt-badge ts" /> {#generics}
+## ジェネリクス <sup class="vt-badge ts" /> {#generics}
 
 `<script>` タグの `generic` 属性を使ってジェネリック型パラメーターを宣言できます:
 


### PR DESCRIPTION
This pull request will update the heading level in the “Generics” section of the `sfc-script-setup.md` file. The heading level has been changed from `###` to `##` for consistency with the original documentation.

Original: https://github.com/vuejs/docs/blob/main/src/api/sfc-script-setup.md#generics--generics

