### PR TITLE
chore(deps): bump @vue/repl from 4.4.1 to 4.4.2

Bumps [@vue/repl](https://github.com/vuejs/repl) from 4.4.1 to 4.4.2.
- [Release notes](https://github.com/vuejs/repl/releases)
- [Changelog](https://github.com/vuejs/repl/blob/main/CHANGELOG.md)
- [Commits](https://github.com/vuejs/repl/compare/v4.4.1...v4.4.2)

---
updated-dependencies:
- dependency-name: "@vue/repl"
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com> (#2320)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@vue/repl':
         specifier: ^4.3.1
-        version: 4.4.1
+        version: 4.4.2
       '@vue/theme':
         specifier: ^2.3.0
         version: 2.3.0(@algolia/client-search@4.20.0)(search-insights@2.14.0)(vitepress@1.3.4(@algolia/client-search@4.20.0)(@types/node@20.14.2)(postcss@8.4.44)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.4.5))(vue@3.5.5(typescript@5.4.5))
@@ -561,8 +561,8 @@ packages:
   '@vue/reactivity@3.5.5':
     resolution: {integrity: sha512-V4tTWElZQhT73PSK3Wnax9R9m4qvMX+LeKHnfylZc6SLh4Jc5/BPakp6e3zEhKWi5AN8TDzRkGnLkp8OqycYng==}
 
-  '@vue/repl@4.4.1':
-    resolution: {integrity: sha512-1IR/6gWungvvKV+ul+hOWid0xBUQft6tw2JqbhoVr/VWl5Vl0sdTmK3xPZF2KtewApQFfqSRqr4+6CohGxzl8A==}
+  '@vue/repl@4.4.2':
+    resolution: {integrity: sha512-MEAsBK/YzMFGINOBzqM40XTeIYAUsg7CqvXvD5zi0rhYEQrPfEUIdexmMjdm7kVKsKmcvIHxrFK2DFC35m9kHw==}
 
   '@vue/runtime-core@3.5.5':
     resolution: {integrity: sha512-2/CFaRN17jgsXy4MpigWFBCAMmLkXPb4CjaHrndglwYSra7ajvkH2cat21dscuXaH91G8fXAeg5gCyxWJ+wCRA==}
@@ -2633,7 +2633,7 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.5
 
-  '@vue/repl@4.4.1': {}
+  '@vue/repl@4.4.2': {}
 
   '@vue/runtime-core@3.5.5':
     dependencies:


### PR DESCRIPTION
resolves #2320
Cherry picked from https://github.com/vuejs/docs/commit/699ca8e9c5d7e842fb08165fb4dc90bc3daabffe