### PR TITLE
fix(guide/suspense): missing v3.3+ badge in suspensible prop

### DIFF
--- a/src/guide/built-ins/suspense.md
+++ b/src/guide/built-ins/suspense.md
@@ -135,6 +135,8 @@ Vue Router には、動的インポートを使用した [lazily loading compone
 
 ## ネストした Suspense {#nested-suspense}
 
+- 3.3 以上でのみサポートされています
+
 次のように複数の非同期コンポーネントがある場合（ネストされたルートやレイアウトベースのルートによくあります）:
 
 ```vue-html


### PR DESCRIPTION
resolve #2318

vuejs/docs@e61a1c0 の反映です