### PR TITLE
docs: fix the description of Writable Computed in Composition API

### DIFF
--- a/src/guide/essentials/computed.md
+++ b/src/guide/essentials/computed.md
@@ -255,7 +255,7 @@ const fullName = computed({
 </script>
 ```
 
-`fullName = 'John Doe'` を呼ぶと、setter 関数が呼び出され、`firstName` と `lastName` が適切に更新されます。
+`fullName.value = 'John Doe'` を呼ぶと、setter 関数が呼び出され、`firstName` と `lastName` が適切に更新されます。
 
 </div>
 


### PR DESCRIPTION
Writable Computedの説明でsetter関数の呼び出し方を修正しました。
英語版は、 `fullName.value = 'John Doe'` になっていました。