### PR TITLE
chore(deps): bump vitepress from 1.4.0 to 1.4.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 4.4.2
       '@vue/theme':
         specifier: ^2.3.0
-        version: 2.3.0(@algolia/client-search@4.20.0)(search-insights@2.14.0)(vitepress@1.4.0(@algolia/client-search@4.20.0)(@types/node@22.7.5)(postcss@8.4.47)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3))(vue@3.5.12(typescript@5.6.3))
+        version: 2.3.0(@algolia/client-search@4.20.0)(search-insights@2.14.0)(vitepress@1.4.1(@algolia/client-search@4.20.0)(@types/node@22.7.5)(postcss@8.4.47)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3))(vue@3.5.12(typescript@5.6.3))
       dynamics.js:
         specifier: ^1.1.5
         version: 1.1.5
@@ -22,7 +22,7 @@ importers:
         version: 3.12.5
       vitepress:
         specifier: ^1.4.0
-        version: 1.4.0(@algolia/client-search@4.20.0)(@types/node@22.7.5)(postcss@8.4.47)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3)
+        version: 1.4.1(@algolia/client-search@4.20.0)(@types/node@22.7.5)(postcss@8.4.47)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3)
       vue:
         specifier: ^3.5.12
         version: 3.5.12(typescript@5.6.3)
@@ -2132,8 +2132,8 @@ packages:
       terser:
         optional: true
 
-  vitepress@1.4.0:
-    resolution: {integrity: sha512-JXCv4EsKTDyAFb6C/UjZr7nsGAzZ6mafVk2rx7rG5o8N+B/4QstIk+iEOe/9dKoU6V624UIC6g1pZ+K63rxhlw==}
+  vitepress@1.4.1:
+    resolution: {integrity: sha512-C2rQ7PMlDVqgsaHOa0uJtgGGWaGv74QMaGL62lxKbtFkYtosJB5HAfZ8+pEbfzzvLemYaYwaiQdFLBlexK2sFw==}
     hasBin: true
     peerDependencies:
       markdown-it-mathjax3: ^4
@@ -2690,7 +2690,7 @@ snapshots:
 
   '@types/hast@3.0.4':
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 3.0.3
 
   '@types/linkify-it@5.0.0': {}
 
@@ -2845,7 +2845,7 @@ snapshots:
 
   '@vue/shared@3.5.12': {}
 
-  '@vue/theme@2.3.0(@algolia/client-search@4.20.0)(search-insights@2.14.0)(vitepress@1.4.0(@algolia/client-search@4.20.0)(@types/node@22.7.5)(postcss@8.4.47)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3))(vue@3.5.12(typescript@5.6.3))':
+  '@vue/theme@2.3.0(@algolia/client-search@4.20.0)(search-insights@2.14.0)(vitepress@1.4.1(@algolia/client-search@4.20.0)(@types/node@22.7.5)(postcss@8.4.47)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3))(vue@3.5.12(typescript@5.6.3))':
     dependencies:
       '@docsearch/css': 3.6.1
       '@docsearch/js': 3.6.1(@algolia/client-search@4.20.0)(search-insights@2.14.0)
@@ -2853,7 +2853,7 @@ snapshots:
       body-scroll-lock: 4.0.0-beta.0
       normalize.css: 8.0.1
       tiny-decode: 0.1.3
-      vitepress: 1.4.0(@algolia/client-search@4.20.0)(@types/node@22.7.5)(postcss@8.4.47)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3)
+      vitepress: 1.4.1(@algolia/client-search@4.20.0)(@types/node@22.7.5)(postcss@8.4.47)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/react'
@@ -4574,7 +4574,7 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.31.0
 
-  vitepress@1.4.0(@algolia/client-search@4.20.0)(@types/node@22.7.5)(postcss@8.4.47)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3):
+  vitepress@1.4.1(@algolia/client-search@4.20.0)(@types/node@22.7.5)(postcss@8.4.47)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3):
     dependencies:
       '@docsearch/css': 3.6.2
       '@docsearch/js': 3.6.2(@algolia/client-search@4.20.0)(search-insights@2.14.0)


### PR DESCRIPTION
resolve #2364

vuejs/docs@a9c6189 の反映です