### PR TITLE
chore(deps): bump vitepress from 1.4.3 to 1.5.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 4.4.2
       '@vue/theme':
         specifier: ^2.3.0
-        version: 2.3.0(@algolia/client-search@4.20.0)(search-insights@2.14.0)(vitepress@1.4.3(@algolia/client-search@4.20.0)(@types/node@22.7.5)(postcss@8.4.47)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3))(vue@3.5.12(typescript@5.6.3))
+        version: 2.3.0(@algolia/client-search@4.20.0)(search-insights@2.14.0)(vitepress@1.5.0(@algolia/client-search@4.20.0)(@types/node@22.7.5)(postcss@8.4.47)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3))(vue@3.5.12(typescript@5.6.3))
       dynamics.js:
         specifier: ^1.1.5
         version: 1.1.5
@@ -22,7 +22,7 @@ importers:
         version: 3.12.5
       vitepress:
         specifier: ^1.4.3
-        version: 1.4.3(@algolia/client-search@4.20.0)(@types/node@22.7.5)(postcss@8.4.47)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3)
+        version: 1.5.0(@algolia/client-search@4.20.0)(@types/node@22.7.5)(postcss@8.4.47)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3)
       vue:
         specifier: ^3.5.12
         version: 3.5.12(typescript@5.6.3)
@@ -331,6 +331,12 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
+
+  '@iconify-json/simple-icons@1.2.11':
+    resolution: {integrity: sha512-AHCGDtBRqP+JzAbBzgO8uN/08CXxEmuaC6lQQZ3b5burKhRU12AJnJczwbUw2K5Mb/U85EpSUNhYMG3F28b8NA==}
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
   '@jridgewell/gen-mapping@0.3.5':
     resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
@@ -2132,8 +2138,8 @@ packages:
       terser:
         optional: true
 
-  vitepress@1.4.3:
-    resolution: {integrity: sha512-956c2K2Mr0ubY9bTc2lCJD3g0mgo0mARB1iJC/BqUt4s0AM8Wl60wSU4zbFnzV7X2miFK1XJDKzGZnuEN90umw==}
+  vitepress@1.5.0:
+    resolution: {integrity: sha512-q4Q/G2zjvynvizdB3/bupdYkCJe2umSAMv9Ju4d92E6/NXJ59z70xB0q5p/4lpRyAwflDsbwy1mLV9Q5+nlB+g==}
     hasBin: true
     peerDependencies:
       markdown-it-mathjax3: ^4
@@ -2447,6 +2453,12 @@ snapshots:
 
   '@esbuild/win32-x64@0.21.5':
     optional: true
+
+  '@iconify-json/simple-icons@1.2.11':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify/types@2.0.0': {}
 
   '@jridgewell/gen-mapping@0.3.5':
     dependencies:
@@ -2845,7 +2857,7 @@ snapshots:
 
   '@vue/shared@3.5.12': {}
 
-  '@vue/theme@2.3.0(@algolia/client-search@4.20.0)(search-insights@2.14.0)(vitepress@1.4.3(@algolia/client-search@4.20.0)(@types/node@22.7.5)(postcss@8.4.47)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3))(vue@3.5.12(typescript@5.6.3))':
+  '@vue/theme@2.3.0(@algolia/client-search@4.20.0)(search-insights@2.14.0)(vitepress@1.5.0(@algolia/client-search@4.20.0)(@types/node@22.7.5)(postcss@8.4.47)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3))(vue@3.5.12(typescript@5.6.3))':
     dependencies:
       '@docsearch/css': 3.6.1
       '@docsearch/js': 3.6.1(@algolia/client-search@4.20.0)(search-insights@2.14.0)
@@ -2853,7 +2865,7 @@ snapshots:
       body-scroll-lock: 4.0.0-beta.0
       normalize.css: 8.0.1
       tiny-decode: 0.1.3
-      vitepress: 1.4.3(@algolia/client-search@4.20.0)(@types/node@22.7.5)(postcss@8.4.47)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3)
+      vitepress: 1.5.0(@algolia/client-search@4.20.0)(@types/node@22.7.5)(postcss@8.4.47)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/react'
@@ -4574,10 +4586,11 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.31.0
 
-  vitepress@1.4.3(@algolia/client-search@4.20.0)(@types/node@22.7.5)(postcss@8.4.47)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3):
+  vitepress@1.5.0(@algolia/client-search@4.20.0)(@types/node@22.7.5)(postcss@8.4.47)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3):
     dependencies:
       '@docsearch/css': 3.6.2
       '@docsearch/js': 3.6.2(@algolia/client-search@4.20.0)(search-insights@2.14.0)
+      '@iconify-json/simple-icons': 1.2.11
       '@shikijs/core': 1.22.2
       '@shikijs/transformers': 1.22.2
       '@shikijs/types': 1.22.2


### PR DESCRIPTION
resolve #2405

vuejs/docs@8061bb2 の反映です