### PR TITLE
docs: add explanation for template-refs defineExpose before await

### DIFF
--- a/src/guide/essentials/template-refs.md
+++ b/src/guide/essentials/template-refs.md
@@ -314,6 +314,8 @@ defineExpose({
 
 親がテンプレート参照を用いてこのコンポーネントのインスタンスを取得する場合、取得されるインスタンスは `{ a: number, b: number }` の形になります（通常のインスタンスと同様に、ref は自動的にアンラップされます）。
 
+defineExpose は必ず await 操作の前に呼び出す必要があります。そうでないと、await 操作の後に公開されるプロパティやメソッドにアクセスできなくなります。
+
 こちらもご覧ください: [コンポーネントのテンプレート参照の型付け](/guide/typescript/composition-api#typing-component-template-refs) <sup class="vt-badge ts" />
 
 </div>


### PR DESCRIPTION
resolve #2447

https://github.com/vuejs/docs/commit/dd5e8c8f0807538dc7e62e5f93cc5646480cb86e の反映です