### PR TITLE
docs: changed lifecycle hooks to be after components basics in sidebar

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -181,15 +181,15 @@ export const sidebar: ThemeConfig['sidebar'] = {
           link: '/guide/essentials/event-handling'
         },
         { text: 'フォーム入力バインディング', link: '/guide/essentials/forms' },
-        {
-          text: 'ライフサイクルフック',
-          link: '/guide/essentials/lifecycle'
-        },
         { text: 'ウォッチャー', link: '/guide/essentials/watchers' },
         { text: 'テンプレート参照', link: '/guide/essentials/template-refs' },
         {
           text: 'コンポーネントの基礎',
           link: '/guide/essentials/component-basics'
+        },
+        {
+          text: 'ライフサイクルフック',
+          link: '/guide/essentials/lifecycle'
         }
       ]
     },


### PR DESCRIPTION
resolve #2445

https://github.com/vuejs/docs/commit/7d15b57975031eaa1c4b0de2398bbabb31327742 の反映です