### PR TITLE
Update component-basics.md - wrong highlight about `slot`

Update component-basics.md

In line 471, the line 4 is highlighted but that's wrong and the line 5 must be highlighted that is about `slot`. (#2471)

### DIFF
--- a/src/api/options-lifecycle.md
+++ b/src/api/options-lifecycle.md
@@ -215,6 +215,12 @@
 
   - `errrorCaptured` フックで `false` を返すと、エラーがそれ以上伝搬しないようにできます。これは要するに「このエラーは処理済みなので無視してください」ということです。このエラーに対して、追加の `errorCaptured` フックや `app.config.errorHandler` が呼び出されるのを防ぎます。
 
+  **Error Capturing Caveats**
+  
+  - In components with async `setup()` function (with top-level `await`) Vue **will always** try to render component template, even if `setup()` throwed error. This will likely cause more errors because during render component's template might try to access non-existing properties of failed `setup()` context. When capturing errors in such components, be ready to handle errors from both failed async `setup()` (they will always come first) and failed render process.
+
+  - <sup class="vt-badge" data-text="SSR only"></sup> Replacing errored child component in parent component deep inside `<Suspense>` will cause hydration mismatches in SSR. Instead, try to separate logic that can possibly throw from child `setup()` into separate function and execute it in the parent component's `setup()`, where you can safely `try/catch` the execution process and make replacement if needed before rendering the actual child component.
+
 ## renderTracked <sup class="vt-badge dev-only" /> {#rendertracked}
 
 コンポーネントのレンダーエフェクトによってリアクティブな依存関係が追跡されたときに呼び出されます。

--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -468,7 +468,7 @@ HTML 要素と同じように、以下のようにコンポーネントにコン
 
 これは Vue のカスタム要素 `<slot>` を用いて実現することができます:
 
-```vue{4}
+```vue{5}
 <!-- AlertBox.vue -->
 <template>
   <div class="alert-box">


### PR DESCRIPTION
resolves #2471
Cherry picked from https://github.com/vuejs/docs/commit/27b5615160b47e1ff5c71ff621db0b2ff34a5462