### PR TITLE
docs: fix typo

### DIFF
--- a/src/api/sfc-script-setup.md
+++ b/src/api/sfc-script-setup.md
@@ -379,7 +379,7 @@ defineExpose({
 
 親がテンプレート参照を介してこのコンポーネントのインスタンスを取得すると、取得されたインスタンスは `{ a: number, b: number }` という形状になります（ref は通常のインスタンスと同様、自動的にアンラップされます）。
 
-## defineOptions() /> {#defineoptions}
+## defineOptions() {#defineoptions}
 
 - 3.3 以上でのみサポートされています
 


### PR DESCRIPTION
### 対応内容
`defineOptions()` の見出しから  ` />` を削除しました。
![image](https://github.com/user-attachments/assets/2981a200-b3ed-4d01-8720-a149a3669912)

### 影響範囲
[該当のページ](https://ja.vuejs.org/api/sfc-script-setup#defineoptions)

ご確認の程よろしくお願いします。