### PR TITLE
chore: bump node version on netlify (#2511)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build.environment]
-  NODE_VERSION = "20"
+  NODE_VERSION = "22"
 
 [build]
   publish = ".vitepress/dist"


### PR DESCRIPTION
resolves #2511
Cherry picked from https://github.com/vuejs/docs/commit/899ec065e760e1f6e85fd545a41d01d59e3f2eb8