### PR TITLE
Swapped Chrome Extension URL to a non-beta version

### DIFF
--- a/src/guide/scaling-up/tooling.md
+++ b/src/guide/scaling-up/tooling.md
@@ -113,7 +113,7 @@ Vue のブラウザー開発者ツール拡張では、Vue アプリのコンポ
 ![devtools screenshot](./images/devtools.png)
 
 - [ドキュメント](https://devtools.vuejs.org/)
-- [Chrome Extension](https://chromewebstore.google.com/detail/vuejs-devtools-beta/ljjemllljcmogpfapbkkighbhhppjdbg)
+- [Chrome Extension](https://chromewebstore.google.com/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd)
 - [Vite プラグイン](https://devtools.vuejs.org/guide/vite-plugin)
 - [スタンドアロンの Electron アプリ](https://devtools.vuejs.org/guide/standalone)
 


### PR DESCRIPTION
resolve #2537 

https://github.com/vuejs/docs/commit/f2de15385040034ffa044ad2f0a37990d1beedbc の反映です