### PR TITLE
chore(deps): bump @vue/repl from 4.5.1 to 4.6.1

Bumps [@vue/repl](https://github.com/vuejs/repl) from 4.5.1 to 4.6.1.
- [Release notes](https://github.com/vuejs/repl/releases)
- [Changelog](https://github.com/vuejs/repl/blob/main/CHANGELOG.md)
- [Commits](https://github.com/vuejs/repl/compare/v4.5.1...v4.6.1)

---
updated-dependencies:
- dependency-name: "@vue/repl"
  dependency-version: 4.6.1
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com> (#2598)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@vue/repl':
         specifier: ^4.4.2
-        version: 4.5.1
+        version: 4.6.1
       '@vue/theme':
         specifier: ^2.3.0
         version: 2.3.0(@algolia/client-search@5.19.0)(search-insights@2.14.0)(vitepress@1.6.3(@algolia/client-search@5.19.0)(@types/node@22.7.5)(postcss@8.5.4)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3))(vue@3.5.16(typescript@5.6.3))
@@ -718,8 +718,8 @@ packages:
   '@vue/reactivity@3.5.16':
     resolution: {integrity: sha512-FG5Q5ee/kxhIm1p2bykPpPwqiUBV3kFySsHEQha5BJvjXdZTUfmya7wP7zC39dFuZAcf/PD5S4Lni55vGLMhvA==}
 
-  '@vue/repl@4.5.1':
-    resolution: {integrity: sha512-YYXvFue2GOrZ6EWnoA8yQVKzdCIn45+tpwJHzMof1uwrgyYAVY9ynxCsDYeAuWcpaAeylg/nybhFuqiFy2uvYA==}
+  '@vue/repl@4.6.1':
+    resolution: {integrity: sha512-tgeEa+QXzqbFsAIbq/dCXzOJxIW2Nq1F79KXRjbKyPt1ODpCx86bDbFgNzFcBEK3In2/mjPTMpN7fSD6Ig0Qsw==}
 
   '@vue/runtime-core@3.5.16':
     resolution: {integrity: sha512-bw5Ykq6+JFHYxrQa7Tjr+VSzw7Dj4ldR/udyBZbq73fCdJmyy5MPIFR9IX/M5Qs+TtTjuyUTCnmK3lWWwpAcFQ==}
@@ -3188,7 +3188,7 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.16
 
-  '@vue/repl@4.5.1': {}
+  '@vue/repl@4.6.1': {}
 
   '@vue/runtime-core@3.5.16':
     dependencies:

--- a/src/ecosystem/themes/themes.json
+++ b/src/ecosystem/themes/themes.json
@@ -337,7 +337,7 @@
         "name": "Sneat - Vue Laravel Admin",
         "price": 0,
         "description": "Free & Open Source VueJS Laravel Admin using Sneat Design System",
-        "url": "https://themeselection.com/item/sneat-free-vuetify-vuejs-laravel-admin-template/ref=14",
+        "url": "https://themeselection.com/item/sneat-free-vuetify-vuejs-laravel-admin-template/?ref=14",
         "image": "https://cdn.themeselection.com/ts-assets/sneat/sneat-vuetify-vuejs-laravel-admin-template-free/banner/banner.png"
       },
       {


### PR DESCRIPTION
resolves #2598
Cherry picked from https://github.com/vuejs/docs/commit/7648af482716e9f6bb9a856135231e58a95a3ae8