### PR TITLE
chore(deps): bump @vue/repl from 4.6.1 to 4.6.2

Bumps [@vue/repl](https://github.com/vuejs/repl) from 4.6.1 to 4.6.2.
- [Release notes](https://github.com/vuejs/repl/releases)
- [Changelog](https://github.com/vuejs/repl/blob/main/CHANGELOG.md)
- [Commits](https://github.com/vuejs/repl/compare/v4.6.1...v4.6.2)

---
updated-dependencies:
- dependency-name: "@vue/repl"
  dependency-version: 4.6.2
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com> (#2608)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@vue/repl':
         specifier: ^4.4.2
-        version: 4.6.1
+        version: 4.6.2
       '@vue/theme':
         specifier: ^2.3.0
         version: 2.3.0(@algolia/client-search@5.19.0)(search-insights@2.14.0)(vitepress@1.6.3(@algolia/client-search@5.19.0)(@types/node@22.7.5)(postcss@8.5.6)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3))(vue@3.5.17(typescript@5.6.3))
@@ -752,8 +752,8 @@ packages:
   '@vue/reactivity@3.5.17':
     resolution: {integrity: sha512-l/rmw2STIscWi7SNJp708FK4Kofs97zc/5aEPQh4bOsReD/8ICuBcEmS7KGwDj5ODQLYWVN2lNibKJL1z5b+Lw==}
 
-  '@vue/repl@4.6.1':
-    resolution: {integrity: sha512-tgeEa+QXzqbFsAIbq/dCXzOJxIW2Nq1F79KXRjbKyPt1ODpCx86bDbFgNzFcBEK3In2/mjPTMpN7fSD6Ig0Qsw==}
+  '@vue/repl@4.6.2':
+    resolution: {integrity: sha512-Rjl/X++MbfWNncry+qiIadY5BdrB3hp0Iu9W7R9eLJAce3hXnjUiykMK5rLAkQJpB6N83SR0LGNJbKg7gpzplg==}
 
   '@vue/runtime-core@3.5.17':
     resolution: {integrity: sha512-QQLXa20dHg1R0ri4bjKeGFKEkJA7MMBxrKo2G+gJikmumRS7PTD4BOU9FKrDQWMKowz7frJJGqBffYMgQYS96Q==}
@@ -3402,7 +3402,7 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.17
 
-  '@vue/repl@4.6.1': {}
+  '@vue/repl@4.6.2': {}
 
   '@vue/runtime-core@3.5.17':
     dependencies:


### PR DESCRIPTION
resolves #2608
Cherry picked from https://github.com/vuejs/docs/commit/6ca6619f81a2038adee9cac845b56cead161c104