### PR TITLE
chore(deps): bump @vue/repl from 4.6.2 to 4.6.3

Bumps [@vue/repl](https://github.com/vuejs/repl) from 4.6.2 to 4.6.3.
- [Release notes](https://github.com/vuejs/repl/releases)
- [Changelog](https://github.com/vuejs/repl/blob/main/CHANGELOG.md)
- [Commits](https://github.com/vuejs/repl/compare/v4.6.2...v4.6.3)

---
updated-dependencies:
- dependency-name: "@vue/repl"
  dependency-version: 4.6.3
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com> (#2623)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@vue/repl':
         specifier: ^4.4.2
-        version: 4.6.2
+        version: 4.6.3
       '@vue/theme':
         specifier: ^2.3.0
         version: 2.3.0(@algolia/client-search@5.19.0)(search-insights@2.14.0)(vitepress@1.6.3(@algolia/client-search@5.19.0)(@types/node@22.7.5)(postcss@8.5.6)(search-insights@2.14.0)(terser@5.31.0)(typescript@5.6.3))(vue@3.5.17(typescript@5.6.3))
@@ -752,8 +752,8 @@ packages:
   '@vue/reactivity@3.5.17':
     resolution: {integrity: sha512-l/rmw2STIscWi7SNJp708FK4Kofs97zc/5aEPQh4bOsReD/8ICuBcEmS7KGwDj5ODQLYWVN2lNibKJL1z5b+Lw==}
 
-  '@vue/repl@4.6.2':
-    resolution: {integrity: sha512-Rjl/X++MbfWNncry+qiIadY5BdrB3hp0Iu9W7R9eLJAce3hXnjUiykMK5rLAkQJpB6N83SR0LGNJbKg7gpzplg==}
+  '@vue/repl@4.6.3':
+    resolution: {integrity: sha512-2ckL15D67pOlnH0wtPHkGCoggCzZiPqWuZbNeYvLQTY24ey6P6GX1TY6b7uruAIC6etecCJQdrGSnc+XXsWDDA==}
 
   '@vue/runtime-core@3.5.17':
     resolution: {integrity: sha512-QQLXa20dHg1R0ri4bjKeGFKEkJA7MMBxrKo2G+gJikmumRS7PTD4BOU9FKrDQWMKowz7frJJGqBffYMgQYS96Q==}
@@ -3402,7 +3402,7 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.17
 
-  '@vue/repl@4.6.2': {}
+  '@vue/repl@4.6.3': {}
 
   '@vue/runtime-core@3.5.17':
     dependencies:


### PR DESCRIPTION
resolves #2623
Cherry picked from https://github.com/vuejs/docs/commit/6379bf1714ed00b178f5ee3274168a1969c8d807