### PR TITLE
docs: different from the original

### DIFF
--- a/src/guide/essentials/template-refs.md
+++ b/src/guide/essentials/template-refs.md
@@ -129,7 +129,7 @@ import Child from './Child.vue'
 const childRef = useTemplateRef('child')
 
 onMounted(() => {
-  // child.value は <Child /> のインスタンスを保持します。
+  // childRef.value は <Child /> のインスタンスを保持します。
 })
 </script>
 


### PR DESCRIPTION
原文とは異なる翻訳になっていました。 `child.value` → `childRef.value`

https://ja.vuejs.org/guide/essentials/template-refs.html#ref-on-component

原文: https://vuejs.org/guide/essentials/template-refs.html#ref-on-component
<img width="730" height="347" alt="image" src="https://github.com/user-attachments/assets/c886652c-43c6-4973-8f36-f26dc70334be" />
