### PR TITLE
Fix a11y: improve sitemap link color contrast to meet WCAG AA

* Fix a11y: improve sitemap link color contrast to meet WCAG AA

* Address review comments: trying to some combination of colors, that would fit better. Not just having the headlines and links the same color. (#2697)

### DIFF
--- a/.vitepress/theme/components/SiteMap.vue
+++ b/.vitepress/theme/components/SiteMap.vue
@@ -62,6 +62,8 @@ const items = nav
 
 #sitemap .vt-link {
   font-size: 0.9em;
-  color: var(--vt-c-text-2);
+  /* increased contrast for better legibility (WCAG 1.4.3) */
+  color: var(--vt-c-text-1);
+  opacity: 0.75;
 }
 </style>


### PR DESCRIPTION
resolves #2697
Cherry picked from https://github.com/vuejs/docs/commit/4610ff099114e7a75d3b1b7f4aa3b2ceed5d9d15