### PR TITLE
docs: remove ambiguous 'versions before 3.5' statement from watcher o…

### DIFF
--- a/src/guide/essentials/watchers.md
+++ b/src/guide/essentials/watchers.md
@@ -486,7 +486,7 @@ export default {
 
 </div>
 
-これは 3.5 以前のバージョンで動作します。また、関数の引数で渡される `onCleanup` はウォッチャーインスタンスにバインドされるため、`onWatcherCleanup` の同期的な制約は受けません。
+関数の引数で渡される `onCleanup` はウォッチャーインスタンスにバインドされるため、`onWatcherCleanup` の同期的な制約は受けません。
 
 ## コールバックが実行されるタイミング {#callback-flush-timing}
 


### PR DESCRIPTION
resolve #2712

https://github.com/vuejs/docs/commit/67abccbebdc871db4fad2c1c39a81808996a81ae の反映です