### PR TITLE
chore(deps): bump vitepress from 2.0.0-alpha.16 to 2.0.0-alpha.17 (#3…

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 4.7.1
       '@vue/theme':
         specifier: ^2.3.0
-        version: 2.3.0(@algolia/client-search@5.19.0)(search-insights@2.14.0)(vitepress@2.0.0-alpha.16(@types/node@24.10.9)(oxc-minify@0.111.0)(postcss@8.5.8)(terser@5.31.0)(typescript@5.9.3)(yaml@2.8.0))(vue@3.5.30(typescript@5.9.3))
+        version: 2.3.0(@algolia/client-search@5.19.0)(search-insights@2.14.0)(vitepress@2.0.0-alpha.17(@types/node@24.10.9)(oxc-minify@0.111.0)(postcss@8.5.8)(terser@5.31.0)(typescript@5.9.3)(yaml@2.8.0))(vue@3.5.30(typescript@5.9.3))
       dynamics.js:
         specifier: ^1.1.5
         version: 1.1.5
@@ -25,7 +25,7 @@ importers:
         version: 3.14.2
       vitepress:
         specifier: ^2.0.0-alpha.15
-        version: 2.0.0-alpha.16(@types/node@24.10.9)(oxc-minify@0.111.0)(postcss@8.5.8)(terser@5.31.0)(typescript@5.9.3)(yaml@2.8.0)
+        version: 2.0.0-alpha.17(@types/node@24.10.9)(oxc-minify@0.111.0)(postcss@8.5.8)(terser@5.31.0)(typescript@5.9.3)(yaml@2.8.0)
       vue:
         specifier: ^3.5.27
         version: 3.5.30(typescript@5.9.3)
@@ -688,9 +688,6 @@ packages:
     peerDependencies:
       vue: 3.5.30
 
-  '@vue/shared@3.5.27':
-    resolution: {integrity: sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ==}
-
   '@vue/shared@3.5.30':
     resolution: {integrity: sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==}
 
@@ -1226,8 +1223,8 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
-  focus-trap@7.8.0:
-    resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
+  focus-trap@8.0.0:
+    resolution: {integrity: sha512-Aa84FOGHs99vVwufDMdq2qgOwXPC2e9U66GcqBhn1/jEHPDhJaP8PYhkIbqG9lhfL5Kddk/567lj46LLHYCRUw==}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -2479,8 +2476,8 @@ packages:
       vite:
         optional: true
 
-  vitepress@2.0.0-alpha.16:
-    resolution: {integrity: sha512-w1nwsefDVIsje7BZr2tsKxkZutDGjG0YoQ2yxO7+a9tvYVqfljYbwj5LMYkPy8Tb7YbPwa22HtIhk62jbrvuEQ==}
+  vitepress@2.0.0-alpha.17:
+    resolution: {integrity: sha512-Z3VPUpwk/bHYqt1uMVOOK1/4xFiWQov1GNc2FvMdz6kvje4JRXEOngVI9C+bi5jeedMSHiA4dwKkff1NCvbZ9Q==}
     hasBin: true
     peerDependencies:
       markdown-it-mathjax3: ^4
@@ -3287,11 +3284,9 @@ snapshots:
       '@vue/shared': 3.5.30
       vue: 3.5.30(typescript@5.9.3)
 
-  '@vue/shared@3.5.27': {}
-
   '@vue/shared@3.5.30': {}
 
-  '@vue/theme@2.3.0(@algolia/client-search@5.19.0)(search-insights@2.14.0)(vitepress@2.0.0-alpha.16(@types/node@24.10.9)(oxc-minify@0.111.0)(postcss@8.5.8)(terser@5.31.0)(typescript@5.9.3)(yaml@2.8.0))(vue@3.5.30(typescript@5.9.3))':
+  '@vue/theme@2.3.0(@algolia/client-search@5.19.0)(search-insights@2.14.0)(vitepress@2.0.0-alpha.17(@types/node@24.10.9)(oxc-minify@0.111.0)(postcss@8.5.8)(terser@5.31.0)(typescript@5.9.3)(yaml@2.8.0))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@docsearch/css': 3.6.1
       '@docsearch/js': 3.6.1(@algolia/client-search@5.19.0)(search-insights@2.14.0)
@@ -3299,7 +3294,7 @@ snapshots:
       body-scroll-lock: 4.0.0-beta.0
       normalize.css: 8.0.1
       tiny-decode: 0.1.3
-      vitepress: 2.0.0-alpha.16(@types/node@24.10.9)(oxc-minify@0.111.0)(postcss@8.5.8)(terser@5.31.0)(typescript@5.9.3)(yaml@2.8.0)
+      vitepress: 2.0.0-alpha.17(@types/node@24.10.9)(oxc-minify@0.111.0)(postcss@8.5.8)(terser@5.31.0)(typescript@5.9.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/react'
@@ -3326,13 +3321,13 @@ snapshots:
       '@vueuse/shared': 14.2.0(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
 
-  '@vueuse/integrations@14.2.0(focus-trap@7.8.0)(vue@3.5.30(typescript@5.9.3))':
+  '@vueuse/integrations@14.2.0(focus-trap@8.0.0)(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@vueuse/core': 14.2.0(vue@3.5.30(typescript@5.9.3))
       '@vueuse/shared': 14.2.0(vue@3.5.30(typescript@5.9.3))
       vue: 3.5.30(typescript@5.9.3)
     optionalDependencies:
-      focus-trap: 7.8.0
+      focus-trap: 8.0.0
 
   '@vueuse/metadata@10.10.0': {}
 
@@ -3799,7 +3794,7 @@ snapshots:
 
   flatted@3.3.3: {}
 
-  focus-trap@7.8.0:
+  focus-trap@8.0.0:
     dependencies:
       tabbable: 6.4.0
 
@@ -5269,7 +5264,7 @@ snapshots:
     optionalDependencies:
       vite: 8.0.0-beta.11(@types/node@24.10.9)(terser@5.31.0)(yaml@2.8.0)
 
-  vitepress@2.0.0-alpha.16(@types/node@24.10.9)(oxc-minify@0.111.0)(postcss@8.5.8)(terser@5.31.0)(typescript@5.9.3)(yaml@2.8.0):
+  vitepress@2.0.0-alpha.17(@types/node@24.10.9)(oxc-minify@0.111.0)(postcss@8.5.8)(terser@5.31.0)(typescript@5.9.3)(yaml@2.8.0):
     dependencies:
       '@docsearch/css': 4.5.4
       '@docsearch/js': 4.5.4
@@ -5281,10 +5276,10 @@ snapshots:
       '@types/markdown-it': 14.1.2
       '@vitejs/plugin-vue': 6.0.4(vite@8.0.0-beta.11(@types/node@24.10.9)(terser@5.31.0)(yaml@2.8.0))(vue@3.5.30(typescript@5.9.3))
       '@vue/devtools-api': 8.0.6
-      '@vue/shared': 3.5.27
+      '@vue/shared': 3.5.30
       '@vueuse/core': 14.2.0(vue@3.5.30(typescript@5.9.3))
-      '@vueuse/integrations': 14.2.0(focus-trap@7.8.0)(vue@3.5.30(typescript@5.9.3))
-      focus-trap: 7.8.0
+      '@vueuse/integrations': 14.2.0(focus-trap@8.0.0)(vue@3.5.30(typescript@5.9.3))
+      focus-trap: 8.0.0
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 3.22.0


### PR DESCRIPTION
resolve #2753

https://github.com/vuejs/docs/commit/77bc26feed68bae570ad9ce7ef91e0b889021a56 の反映です