### PR TITLE
chore(deps): bump @vue/repl from 4.7.1 to 4.7.2

Bumps [@vue/repl](https://github.com/vuejs/repl) from 4.7.1 to 4.7.2.
- [Release notes](https://github.com/vuejs/repl/releases)
- [Changelog](https://github.com/vuejs/repl/blob/main/CHANGELOG.md)
- [Commits](https://github.com/vuejs/repl/compare/v4.7.1...v4.7.2)

---
updated-dependencies:
- dependency-name: "@vue/repl"
  dependency-version: 4.7.2
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com> (#2763)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
     dependencies:
       '@vue/repl':
         specifier: ^4.7.1
-        version: 4.7.1
+        version: 4.7.2
       '@vue/theme':
         specifier: ^2.4.0
         version: 2.4.0(@algolia/client-search@5.19.0)(search-insights@2.14.0)(vitepress@2.0.0-alpha.17(@types/node@25.5.2)(oxc-minify@0.124.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1))(postcss@8.5.8)(terser@5.31.0)(typescript@5.9.3)(yaml@2.8.0))(vue@3.5.32(typescript@5.9.3))
@@ -701,8 +701,8 @@ packages:
   '@vue/reactivity@3.5.32':
     resolution: {integrity: sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==}
 
-  '@vue/repl@4.7.1':
-    resolution: {integrity: sha512-8w5Z3cyqBJ5ufzXO2eut2stzb7aX/ZnSva2d3ee8eEINEB7FG2JYwc14eAHHHGGuoXOGN5v4cyb5ti/YZGcwlg==}
+  '@vue/repl@4.7.2':
+    resolution: {integrity: sha512-6x0hisEd5XRYxhLit3fvPCfeUfXEjB3a8Z2Pl3scVa3kZjck4+ERQF4XCahC7PTabWb3He04u+j8q3MK4WZHrQ==}
 
   '@vue/runtime-core@3.5.32':
     resolution: {integrity: sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==}
@@ -3324,7 +3324,7 @@ snapshots:
     dependencies:
       '@vue/shared': 3.5.32
 
-  '@vue/repl@4.7.1': {}
+  '@vue/repl@4.7.2': {}
 
   '@vue/runtime-core@3.5.32':
     dependencies:


### PR DESCRIPTION
resolves #2763
Cherry picked from https://github.com/vuejs/docs/commit/cccdebc775b648793aade100a0c11bda2db3bc3a