### PR TITLE
ci: add explicit GITHUB_TOKEN permissions to CI workflows

### DIFF
--- a/.github/workflows/ja.yaml
+++ b/.github/workflows/ja.yaml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   textlint:
 

--- a/.github/workflows/ryu-cho.yaml
+++ b/.github/workflows/ryu-cho.yaml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '*/5 * * * *'
 
+permissions:
+  contents: read
+
 jobs:
   ryu-cho:
     name: Ryu Cho


### PR DESCRIPTION
ref: https://github.com/vitejs/docs-ja/pull/2610