### PR TITLE
fix: add self-closing slash to v-model with argument and modifier example (#2807)

### DIFF
--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -524,7 +524,7 @@ export default {
 引数と修飾子の両方を持つ `v-model` バインディングの場合、生成される props の名前は `arg + "Modifiers"` になります。例えば:
 
 ```vue-html
-<MyComponent v-model:title.capitalize="myText">
+<MyComponent v-model:title.capitalize="myText" />
 ```
 
 対応する宣言は次のとおりです:


### PR DESCRIPTION
resolves #2807
Cherry picked from https://github.com/vuejs/docs/commit/142fa3cc918500c8829c7d0abdd5e3e2ab7a72bc