### PR TITLE
fix: change js to ts code fence for Options API emits TypeScript example (#2809)

### DIFF
--- a/src/guide/components/events.md
+++ b/src/guide/components/events.md
@@ -208,7 +208,7 @@ const emit = defineEmits<{
 </div>
 <div class="options-api">
 
-```js
+```ts
 export default {
   emits: {
     submit(payload: { email: string, password: string }) {

--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -524,7 +524,7 @@ export default {
 引数と修飾子の両方を持つ `v-model` バインディングの場合、生成される props の名前は `arg + "Modifiers"` になります。例えば:
 
 ```vue-html
-<MyComponent v-model:title.capitalize="myText">
+<MyComponent v-model:title.capitalize="myText" />
 ```
 
 対応する宣言は次のとおりです:


### PR DESCRIPTION
resolves #2809
Cherry picked from https://github.com/vuejs/docs/commit/c3046b456388d67751f0d71f06950fb468a30310