### PR TITLE
fix: replace _.debounce with debounce in stateful methods example

### DIFF
--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -580,7 +580,7 @@ export default {
 export default {
   created() {
     // 各インスタンスがデバウンスされたハンドラーのコピーを持つようになりました。
-    this.debouncedClick = _.debounce(this.click, 500)
+    this.debouncedClick = debounce(this.click, 500)
   },
   unmounted() {
     // また、タイマーをキャンセルするのも良いアイデアです


### PR DESCRIPTION
resolve #2811

https://github.com/vuejs/docs/commit/2a72ae9b88ac94a1ddd12a0e29fbcf9bfe67b1c4 の反映です