### PR TITLE
ci: yuki-no の実行間隔を2時間おきに変更

### DIFF
--- a/.github/workflows/yuki-no.yml
+++ b/.github/workflows/yuki-no.yml
@@ -2,7 +2,7 @@ name: yuki-no
 
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '0 */2 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- GitHub Actions API側の一時的な不整合により yuki-no の同期処理が断続的に失敗し、通知が頻発していたため、実行間隔を5分おきから2時間おきに変更する暫定対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Ke813D87GFuTkLCTshuPp